### PR TITLE
Bugfix: Included templates now are always compiled if 'compileAtEveryRender=true'.

### DIFF
--- a/teddy.js
+++ b/teddy.js
@@ -341,7 +341,7 @@
           }
 
           // compile included template if necessary
-          if (!teddy.compiledTemplates[src]) {
+          if (!teddy.compiledTemplates[src] || teddy.params.compileAtEveryRender) {
             teddy.compile(src);
           }
 


### PR DESCRIPTION
The 'compileAtEveryRender=true' setting was only forcing main templates to be compiled every time. Included templates were still being compiled only one time after starting the server. This change will force included templates also to be compiled every time if 'compileAtEveryRender=true'.
