### PR TITLE
Add unit tests for one line if reverse quotes

### DIFF
--- a/test/conditionals.js
+++ b/test/conditionals.js
@@ -173,4 +173,14 @@ describe('Conditionals', function() {
     assert.equalIgnoreSpaces(teddy.render('conditionals/ifNestedProperties.html', model), '<p>Should render</p>');
     done();
   });
+
+  it('should evaluate one line if "if-something" as true with quote types reversed (conditionals/oneLineReverseQuotes.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('conditionals/oneLineReverseQuotes.html', model), '<p class="something-true">One line if.</p>');
+    done();
+  });
+
+  it('should evaluate one line if "if-something" as true with quote types reversed and a variable result (conditionals/oneLineReverseQuotesVar.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('conditionals/oneLineReverseQuotesVar.html', model), '<p class="Some content">One line if.</p>');
+    done();
+  });
 });

--- a/test/includes.js
+++ b/test/includes.js
@@ -79,4 +79,9 @@ describe('Includes', function() {
     assert.equal(teddy.render('includes/includeInfiniteLoop.html', model), 'Render aborted due to max number of passes (100) exceeded; there is a possible infinite loop in your template logic.');
     done();
   });
+
+  it('should evaluate a nested reverse quotes oneliner with an arg passed to it (includes/nestedOneliner.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('includes/nestedOneliner', model), '<p class=\'Some content\'>One line if.</p>');
+    done();
+  });
 });

--- a/test/templates/conditionals/oneLineReverseQuotes.html
+++ b/test/templates/conditionals/oneLineReverseQuotes.html
@@ -1,0 +1,4 @@
+{!
+  should evaluate one line if "if-something" as true with quote types reversed
+!}
+<p if-something true='class="something-true"' false='class="something-false"'>One line if.</p>

--- a/test/templates/conditionals/oneLineReverseQuotesVar.html
+++ b/test/templates/conditionals/oneLineReverseQuotesVar.html
@@ -1,0 +1,4 @@
+{!
+  should evaluate one line if "if-something" as true with quote types reversed and a variable result
+!}
+<p if-something true='class="{something}"' false='class="something-false"'>One line if.</p>

--- a/test/templates/includes/nestedOneliner.html
+++ b/test/templates/includes/nestedOneliner.html
@@ -1,0 +1,6 @@
+{!
+  should evaluate a nested reverse quotes oneliner with an arg passed to it
+!}
+<include src='conditionals/oneLineReverseQuotesVar'>
+  <arg misc>Hello</arg>
+</include>


### PR DESCRIPTION
Here it is, the test we've been waiting for to replicate the bug in #110!

I've pinpointed that this bug is caused by this regex https://github.com/rooseveltframework/teddy/blob/master/teddy.js#L1234

Specifically when we pass a one line if element that meets the circumstances of the test to that match the result comes out incorrect, which ends up cancelling out the evaluation of the variable. (In this particular case we end up getting `data-local-model=` instead of `data-local-model='0'`)

I also created similar tests for the individual pieces of bug, which aren't broken, but act as a sort of control.