### PR TITLE
Tests for Teddy compiling via string and file

### DIFF
--- a/test/misc.js
+++ b/test/misc.js
@@ -24,6 +24,21 @@ describe('Misc', function () {
     }
   })
 
+  it('should compile a template with source code as the parameter and populate teddy.templates', function (done) {
+    var templateAsString = '{! should properly escape HTML entities present in {variables} !} <p>{escapeTest}</p>'
+    var templateNameAndPath = 'something'
+    teddy.compile(templateAsString)
+    assert(teddy.templates[templateNameAndPath] !== undefined)
+    done()
+  })
+
+  it('should compile a template with a path to a template as the parameter and populate teddy.templates', function (done) {
+    var templateNameAndPath = 'misc/varNoEscaping.html'
+    teddy.compile(templateNameAndPath)
+    assert(teddy.templates[templateNameAndPath] !== undefined)
+    done()
+  })
+
   it('should not escape HTML entities present in {variables} which are properly {flagged|p|s} (misc/barPandSTest.html)', function (done) {
     assert.equalIgnoreSpaces(teddy.render('misc/barPandSTest.html', model), '<h1>double bars</h1> {something}')
     done()


### PR DESCRIPTION
This PR serves as both a question/discussion and possible enhancement.

`teddy.compile(pathToFile)` seems to work as I expect, but `teddy.compile(someString)` does not.

According to the API it is suppose to populate `teddy.templates`, the compiling via file does populate `teddy.templates` but the string doesn't. But this also poses a question, what do we use for a key when we are compiling a string template. I see it is suppose to use [`name` which is equal to `template`](https://github.com/rooseveltframework/teddy/blob/b6da8210f0073f2eccb4db785bda1c98334f0913/teddy.js#L198-L199), this works in the filename case but doesn't make sense in the string case.

Let me know if I am approaching this incorrectly or if I can clarify further.