### PR TITLE
Adding type definitions to Teddy

### DIFF
--- a/teddy.d.ts
+++ b/teddy.d.ts
@@ -1,0 +1,22 @@
+// Definitions for Teddy API
+declare namespace teddy {
+  export function compile (template: string): string;
+  export function render (template: string, model: object): string;
+  export function setTemplateRoot (path: string): void;
+  export function setVerbosity (n: number): void;
+  export function cacheRenders (b: boolean): void;
+  export function setDefaultCaches (n: number): void;
+  export function setMaxCaches (template: string, n: number): void;
+  export function setCacheWhitelist (o: object): void;
+  export function setCacheBlacklist (templateArray: string[]): void;
+  export function setDefaultParams (): void;
+  export function flushCache (template: string): void;
+  export function flushCache (template: string, model: object): void;
+  export function setMaxPasses (n: number): void;
+  export function compileAtEveryRender (b: boolean): void;
+  export function minify (b: boolean): void;
+
+  export var templates: object;
+}
+
+export = teddy;


### PR DESCRIPTION
Typescript has defined a file called a definitions file which you can declare the types of JS/TS code. Even though this isn't a TS project, it can be handy for code completions and intellisense in VS Code for Teddy.

![screen shot 2018-08-16 at 8 19 28 pm](https://user-images.githubusercontent.com/3685876/44241597-ee4b2780-a192-11e8-9f9b-ee7876cda033.png)

The first example is when importing teddy into a project using `require('teddy')`, VS Code will understand all of the functions defined in the type def file. With such, it will do auto-completion on the namespace as soon as you type in `teddy.`.

![screen shot 2018-08-16 at 8 19 47 pm](https://user-images.githubusercontent.com/3685876/44241643-38340d80-a193-11e8-9fcc-239e293ffdb5.png)

As well, it will present the entire type signature for a function and it's parameters so it can give hints to the user on what should be inputted when filling out arguments.

This doesn't modify Teddy itself in any way, but the file will be need to be updated whenever there are any changes to the public API.
