### PR TITLE
new unit test that fails for onelineif's

### DIFF
--- a/test/conditionals.js
+++ b/test/conditionals.js
@@ -265,6 +265,11 @@ describe('Conditionals', function () {
     done()
   })
 
+  it('should ignore \'if-\' when not part of an if statement when \'if-\' is part of an attribute\'s value', function (done) {
+    assert.equalIgnoreSpaces(teddy.render('conditionals/oneLineIfInsideAttribute.html', model), '<p id=\'gif-jpg-png\'>hello</p> <p class=\'gif-jpg-png\'>hello</p><p filter=\'gif-jpg-png\'>hello</p>')
+    done()
+  })
+
   it('should ignore \'if-\' when not part of an if statement when combined with a one line if statement, reversed. (conditionals/oneLineIfOutsideIfReverse.html)', function (done) {
     assert.equalIgnoreSpaces(teddy.render('conditionals/oneLineIfOutsideIfReverse.html', model), '<p class=\'something-is-present\'>  gif-jpg-png </p>')
     done()

--- a/test/templates/conditionals/oneLineIfInsideAttribute.html
+++ b/test/templates/conditionals/oneLineIfInsideAttribute.html
@@ -1,0 +1,7 @@
+{!
+  should ignore \'if-\' when its part of an attribute's value
+!}
+
+<p id='gif-jpg-png'>hello</p>
+<p class='gif-jpg-png'>hello</p>
+<p filter='gif-jpg-png'>hello</p>


### PR DESCRIPTION
Added unit test to show onelineif's break when the string `if-` is within a attributes value.