### PR TITLE
Fixing more CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      - run: npm run build
       - run: npm run lint
       - run: npm run coverage
       - run: npm run codecov

--- a/conditionals.js
+++ b/conditionals.js
@@ -237,7 +237,7 @@ function parseOneLineIf (charList, model) {
     // Get teddy var name
     if (readingName) {
       // Done with name and onto true/false values next
-      if (currentChar === ' ' || currentChar === '\n') {
+      if (currentChar === ' ' || currentChar === '\n' || currentChar === '\r') {
         readingConditions = true
         readingName = false
         condition.varName = conditionVarName.slice(3)
@@ -250,7 +250,7 @@ function parseOneLineIf (charList, model) {
       }
     } else if (readingLiteral) { // Get expected literal value if it exists
       // We are done reading expected literal value
-      if ((currentChar === ' ' || currentChar === '\n') && (conditionLiteral[conditionLiteral.length - 1] === '"' || conditionLiteral[conditionLiteral.length - 1] === "'" || conditionLiteral[conditionLiteral.length - 1] === '}')) {
+      if ((currentChar === ' ' || currentChar === '\n' || currentChar === '\r') && (conditionLiteral[conditionLiteral.length - 1] === '"' || conditionLiteral[conditionLiteral.length - 1] === "'" || conditionLiteral[conditionLiteral.length - 1] === '}')) {
         readingConditions = true
         readingLiteral = false
 
@@ -264,7 +264,7 @@ function parseOneLineIf (charList, model) {
         conditionLiteral += currentChar
       }
     } else if (readingConditions) { // Get True/False conditions in the oneline-if
-      if ((currentChar === ' ' || currentChar === '\n') && (charList[i + 1] === currentQuote || charList[i + 1] === ' ' || charList[i + 1] === '\n')) {
+      if ((currentChar === ' ' || currentChar === '\n' || currentChar === '\r') && (charList[i + 1] === currentQuote || charList[i + 1] === ' ' || charList[i + 1] === '\n' || charList[i + 1] === '\r')) {
         if (conditionText.slice(0, 4) === 'true') {
           condition.true = conditionText.slice(6, -1)
         } else if (conditionText.slice(0, 5) === 'false') {
@@ -296,7 +296,7 @@ function parseOneLineIf (charList, model) {
         }
         conditionText += currentChar
       }
-    } else if ((currentChar === ' ' || currentChar === '\n') && twoArraysEqual(charList.slice(i - 3, i), primaryTags.olif)) { // Possible beginning for oneline-if
+    } else if ((currentChar === ' ' || currentChar === '\n' || currentChar === '\r') && twoArraysEqual(charList.slice(i - 3, i), primaryTags.olif)) { // Possible beginning for oneline-if
       readingName = true
       startIndex = i
     }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,17 +1,10 @@
 // Karma configuration
-const os = require('os')
-
 module.exports = function (config) {
   // default browsers to test on
   const testBrowsers = [
     'ChromeHeadless',
     'FirefoxHeadless'
   ]
-
-  // add Safari if in macOS
-  if (os.platform() === 'darwin') {
-    testBrowsers.push('Safari')
-  }
 
   const configuration = {
     basePath: '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4356,12 +4356,6 @@
         "minimist": "^1.2.3"
       }
     },
-    "karma-safari-launcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
-      "integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
-      "dev": true
-    },
     "karma-spec-reporter": {
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.32.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "karma-firefox-launcher": "~1.3.0",
     "karma-html2js-preprocessor": "~1.1.0",
     "karma-mocha": "~2.0.1",
-    "karma-safari-launcher": "~1.0.0",
     "karma-spec-reporter": "~0.0.32",
     "lint-staged": "~10.2.4",
     "mocha": "~7.2.0",

--- a/scanTemplate.js
+++ b/scanTemplate.js
@@ -26,7 +26,7 @@ function scanTemplate (charList, model, escapeOverride, passes, fs, endParse, cu
             charList = removeTeddyComment(charList)
           } else if (charList[charList.length - 2] === '~') { // Internal notation for a noteddy block of text
             [charList, renderedTemplate] = noParseTeddyVariable(charList, renderedTemplate)
-          } else if (charList[charList.length - 2] === ' ' || charList[charList.length - 2] === '\n') { // Plain text curly bracket
+          } else if (charList[charList.length - 2] === ' ' || charList[charList.length - 2] === '\n' || charList[charList.length - 2] === '\r') { // Plain text curly bracket
           } else { // Replace teddy {variable} with its value in the model
             charList = getValueAndReplace(charList, model, escapeOverride)
           }
@@ -106,7 +106,7 @@ function scanTemplate (charList, model, escapeOverride, passes, fs, endParse, cu
         renderedTemplate += charList[charList.length - 1]
 
         // add an extra space for js within html template
-        if ((charList[charList.length - 1] === '{' || charList[charList.length - 1] === ';') && charList[charList.length - 2] === '\n') {
+        if ((charList[charList.length - 1] === '{' || charList[charList.length - 1] === ';') && (charList[charList.length - 2] === '\n' || charList[charList.length - 2] === '\r')) {
           renderedTemplate += ' '
         }
         charList.pop()

--- a/utils.js
+++ b/utils.js
@@ -219,7 +219,7 @@ function findTeddyTag (charList, tags) {
     currentChar = charList[i]
     if (currentChar === '>' || currentChar === '<') { // stop checking if we see an open bracket '<' for a tag
       break
-    } else if (currentChar === ' ' || currentChar === '\n') { // possible oneline-if
+    } else if (currentChar === ' ' || currentChar === '\n' || currentChar === '\r') { // possible oneline-if
       if (twoArraysEqual(charList.slice(i - 3, i), primaryTags.olif)) { // definite oneline-if
         return 'one-line-if'
       }


### PR DESCRIPTION
Windows uses CRLF for their newline which we weren't accounting for. As well this adds a `npm run build` step in the CI so the browser bundle is available to the karma tests.

As well removing karma-safari-launcher due to it not working on MacOS Mojave & Catalina

Closes #392 