### PR TITLE
test for nested if inside of else failing

### DIFF
--- a/test/conditionals.js
+++ b/test/conditionals.js
@@ -250,6 +250,11 @@ describe('Conditionals', function () {
     done()
   })
 
+  it('should parse nested conditionals correctly (conditionals/nestedConditionalInElse.html)', function (done) {
+    assert.equalIgnoreSpaces(teddy.render('conditionals/nestedConditionalInElse.html', model), '<p>The variable \'something\' and \'somethingElse\' are both present</p>')
+    done()
+  })
+
   it('should render nothing if condition isn\'t met (conditionals/ifNotPresent.html)', function (done) {
     assert.equalIgnoreSpaces(teddy.render('conditionals/ifNotPresent.html', model), '<div></div>')
     done()

--- a/test/templates/conditionals/nestedConditionalInElse.html
+++ b/test/templates/conditionals/nestedConditionalInElse.html
@@ -1,0 +1,20 @@
+{!
+    should evaluate <if something> as true and the nested <if not:somethingElse> as false, triggering the nested <else> condition
+  !}
+  <if something>
+    <if not:somethingElse>
+      <p>The variable 'somethingElse' is not present but 'something' is</p>
+    </if>
+    <else>
+      <p>The variable 'something' and 'somethingElse' are both present</p>
+    </else>
+  </if>
+  <elseif somethingElse>
+    <p>The variable 'somethingElse' is present but 'something' is not</p>
+  </elseif>
+  <else>
+    <if something>
+      <p>The variable 'something' is not present and the variable 'somethingElse' is not present</p>
+    </if>
+  </else>
+  


### PR DESCRIPTION
Altered the original html template for `templates/nestedConditional.html` to include an `<if>` tag inside of an `<else>` tag that shouldn't be getting parsed since it should evaluate the first `<if>` to be true.

Teddy produces as output for this 
```


      <p>The variable 'something' and 'somethingElse' are both present</p>


  <else>

      <p>The variable 'something' is not present and the variable 'somethingElse' is not present</p>
```
instead of the correct 
```
<p>The variable 'something' and 'somethingElse' are both present</p>
```