### PR TITLE
0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Put your changes here...
 
+## 0.5.10
+
+- Fixed bug with one-line-ifs. See https://github.com/rooseveltframework/teddy/pull/540
+- Various dependencies bumped
+
 ## 0.5.9
 
 - Fixed an issue where model content could get printed without being escaped even when the `|s` flag is not present.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teddy",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "teddy",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "CC-BY-4.0",
       "devDependencies": {
         "c8": "~7.11.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/teddy/graphs/contributors"
     }
   ],
-  "version": "0.5.9",
+  "version": "0.5.10",
   "files": [
     "dist/teddy.js"
   ],


### PR DESCRIPTION
- Fixed bug with one-line-ifs. See https://github.com/rooseveltframework/teddy/pull/540
- Various dependencies bumped