### PR TITLE
0.6.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules
 coverage
 dist
 test-results
+test/client.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Put your changes here...
 
+## 0.6.11
+
+- Added new setting `teddy.setEmptyVarBehavior('hide')` that will make it possible for variables which don't resolve to display as empty strings instead of displaying the variable.
+
 ## 0.6.10
 
 - Added support for template literal `${templateLiteral}` variables.

--- a/README.md
+++ b/README.md
@@ -483,6 +483,9 @@ API documentation
 - `teddy.maxPasses(n)`: Sets the maximum number of passes the parser can execute over your template. If this maximum is exceeded, Teddy will stop attempting to render the template. The limit exists to prevent the possibility of teddy producing infinite loops due to improperly coded templates.
   - Default: 1000.
 
+- `teddy.setEmptyVarBehavior('hide')`: Will make it possible for variables which don't resolve to display as empty strings instead of displaying the variable.
+  - Default: 'display'.
+
 - `teddy.setCache(params)`: Declare a template-level cache.
 
   - Params:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teddy",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teddy",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cheerio": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/teddy/graphs/contributors"
     }
   ],
-  "version": "0.6.10",
+  "version": "0.6.11",
   "files": [
     "dist"
   ],

--- a/test/tests.js
+++ b/test/tests.js
@@ -919,6 +919,17 @@ export default [
         expected: '<p>Some content</p>'
       },
       {
+        message: 'should render {variables} as blank when x is true (misc/undefinedVar.html)',
+        template: 'misc/undefinedVar',
+        test: (teddy, template, model) => {
+          teddy.setEmptyVarBehavior('hide')
+          const result = teddy.render(template, model)
+          teddy.setEmptyVarBehavior('display')
+          return result
+        },
+        expected: '<p></p><p></p>'
+      },
+      {
         message: 'should render template literal ${variables} (misc/variableTemplateLiteral.html)', // eslint-disable-line
         template: 'misc/variableTemplateLiteral',
         test: (teddy, template, model) => teddy.render(template, model),
@@ -1640,7 +1651,7 @@ export default [
           fs.writeFileSync('test/client.cjs', 'const teddy = require("../dist/teddy.cjs")\nconsole.log(teddy)')
           const output = execSync('node ./test/client.cjs', { encoding: 'utf-8' }).toString()
 
-          assert(output.includes('params: { verbosity:'))
+          assert(output.includes('emptyVarBehavior:'))
 
           fs.rmSync('test/client.cjs')
         },
@@ -1655,7 +1666,7 @@ export default [
           fs.writeFileSync('test/client.js', 'import teddy from "../dist/teddy.js"\nconsole.log(teddy)')
           const output = execSync('node ./test/client.js', { encoding: 'utf-8' }).toString()
 
-          assert(output.includes('params: { verbosity:'))
+          assert(output.includes('emptyVarBehavior:'))
 
           fs.rmSync('test/client.js')
         },


### PR DESCRIPTION
- Added new setting `teddy.setEmptyVarBehavior('hide')` that will make it possible for variables which don't resolve to display as empty strings instead of displaying the variable.