### PR TITLE
0.6.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - Put your changes here...
 
+## 0.6.17
+
+- Fixed a bug which caused client-side Teddy to handle array length lookups differently from `cheerio`-driven Teddy.
+- Fixed a bug which caused client-side Teddy to crash if extra spaces were in markup attribute lists.
+- Fixed a bug which caused client-side Teddy to return the wrong data with 2 or more layers of object lookups if the object keys were camelCase.
+- Fixed a bug which caused client-side Teddy to rename some form elements accidentally.
+- Updated various dependencies.
+
 ## 0.6.16
 
 - Fixed a bug which caused client-side Teddy to fail in some situations like putting a `<loop>` in a `<select>` element.

--- a/cheerioPolyfill.js
+++ b/cheerioPolyfill.js
@@ -122,7 +122,13 @@ function parseTeddyDOMFromString (html) {
         }
 
         // apply attributes to the element
-        for (const [name, value] of attrMap) element.setAttribute(name, value || '')
+        for (const [name, value] of attrMap) {
+          try {
+            element.setAttribute(name, value || '')
+          } catch (e) {
+            console.warn('Error parsing an element attribute. You might have a typo in your HTML. A common cause is two spaces between element attributes.')
+          }
+        }
 
         // append the new element to the current parent
         dom[dom.length - 1].appendChild(element)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teddy",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teddy",
-      "version": "0.6.16",
+      "version": "0.6.17",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cheerio": "1.0.0"
@@ -16,7 +16,7 @@
         "c8": "10.1.2",
         "codecov": "3.8.3",
         "cross-env": "7.0.3",
-        "eslint": "9.14.0",
+        "eslint": "9.15.0",
         "eslint-plugin-html": "8.1.2",
         "eslint-plugin-mocha": "10.5.0",
         "mocha": "10.8.2",
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
+      "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-      "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
+      "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
-      "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
+      "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1825,9 +1825,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.57",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.57.tgz",
-      "integrity": "sha512-xS65H/tqgOwUBa5UmOuNSLuslDo7zho0y/lgQw35pnrqiZh7UOWHCeL/Bt6noJATbA6tpQJGCifsFsIRZj1Fqg==",
+      "version": "1.5.60",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.60.tgz",
+      "integrity": "sha512-HcraRUkTKJ+8yA3b10i9qvhUlPBRDlKjn1XGek1zDGVfAKcvi8TsUnImGqLiEm9j6ZulxXIWWIo9BmbkbCTGgA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1901,9 +1901,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.4.tgz",
-      "integrity": "sha512-HR1gxH5OaiN7XH7uiWH0RLw0RcFySiSoW1ctxmD1ahTw3uGBtkmm/ng0tDU1OtYx5OK6EOL5Y6O21cDflG3Jcg==",
+      "version": "1.23.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
+      "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2098,27 +2098,27 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
-      "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
+      "integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.18.0",
-        "@eslint/core": "^0.7.0",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.14.0",
-        "@eslint/plugin-kit": "^0.2.0",
+        "@eslint/config-array": "^0.19.0",
+        "@eslint/core": "^0.9.0",
+        "@eslint/eslintrc": "^3.2.0",
+        "@eslint/js": "9.15.0",
+        "@eslint/plugin-kit": "^0.2.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.0",
+        "@humanwhocodes/retry": "^0.4.1",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.5",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^8.2.0",
@@ -2137,8 +2137,7 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/teddy/graphs/contributors"
     }
   ],
-  "version": "0.6.16",
+  "version": "0.6.17",
   "files": [
     "dist"
   ],
@@ -34,7 +34,7 @@
     "c8": "10.1.2",
     "codecov": "3.8.3",
     "cross-env": "7.0.3",
-    "eslint": "9.14.0",
+    "eslint": "9.15.0",
     "eslint-plugin-html": "8.1.2",
     "eslint-plugin-mocha": "10.5.0",
     "mocha": "10.8.2",

--- a/teddy.js
+++ b/teddy.js
@@ -720,8 +720,8 @@ function cleanupStrayTeddyTags (dom) {
     const tags = dom('[teddydeferredonelineconditional], include, arg, if, unless, elseif, elseunless, else, loop, cache')
     if (tags.length > 0) {
       for (const el of tags) {
-        if (browser) el.name = el.nodeName?.toLowerCase()
-        if (el.name === 'include' || el.name === 'arg' || el.name === 'if' || el.name === 'unless' || el.name === 'elseif' || el.name === 'elseunless' || el.name === 'else' || el.name === 'loop' || el.name === 'cache') {
+        const tagName = browser ? el.nodeName?.toLowerCase() : el.name
+        if (tagName === 'include' || tagName === 'arg' || tagName === 'if' || tagName === 'unless' || tagName === 'elseif' || tagName === 'elseunless' || tagName === 'else' || tagName === 'loop' || tagName === 'cache') {
           dom(el).remove()
         }
         if (browser) el.attribs = getAttribs(el)
@@ -831,8 +831,13 @@ function getOrSetObjectByDotNotation (obj, dotNotation, value) {
       else return obj[dotNotation[0]]
     }
     return false
-  } else return getOrSetObjectByDotNotation(obj[dotNotation[0]], dotNotation.slice(1), value)
+  } else {
+    if (browser) obj = caseInsensitiveLookup(obj, dotNotation[0])
+    else obj = obj[dotNotation[0]]
+    return getOrSetObjectByDotNotation(obj, dotNotation.slice(1), value)
+  }
   function caseInsensitiveLookup (obj, key) {
+    if (key === 'length') return obj.length
     const lowerCaseKey = key.toLowerCase()
     const normalizedObj = Object.keys(obj).reduce((acc, k) => {
       acc[k.toLowerCase()] = obj[k]

--- a/test/model.js
+++ b/test/model.js
@@ -117,6 +117,14 @@ export default function makeModel () {
         }
       }
     ],
+    topObj: {
+      subObj: {
+        one: 1,
+        zero: 0,
+        emptyArray: [],
+        populatedArray: ['fds', 'hgf', 'jkf']
+      }
+    },
     nestedObj: {
       'Thing With Name 1': {
         'Subthing With Name 1': [

--- a/test/templates/conditionals/ifArrayLengthZero.html
+++ b/test/templates/conditionals/ifArrayLengthZero.html
@@ -1,0 +1,24 @@
+{!
+  should evaluate conditionals that examine array lengths correctly
+!}
+
+<p>{topObj.subObj.one}</p>
+<p>{topObj.subObj.zero}</p>
+<p>{topObj.subObj.emptyArray}</p>
+<p>{topObj.subObj.emptyArray.length}</p>
+<p>{topObj.subObj.populatedArray.length}</p>
+<if topObj.subObj.one="1">
+  <p>1 is present</p>
+</if>
+<if topObj.subObj.zero="0">
+  <p>0 is present</p>
+</if>
+<if topObj.subObj.emptyArray>
+  <p>emptyArray is present</p>
+</if>
+<if topObj.subObj.emptyArray.length="0">
+  <p>emptyArray length is 0</p>
+</if>
+<if topObj.subObj.populatedArray.length="3">
+  <p>populatedArray length is 3</p>
+</if>

--- a/test/tests.js
+++ b/test/tests.js
@@ -55,6 +55,12 @@ export default [
         expected: '<p>The variable \'something\' is present</p>'
       },
       {
+        message: 'should evaluate conditionals that examine array lengths correctly (conditionals/ifArrayLengthZero.html)',
+        template: 'conditionals/ifArrayLengthZero',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p>1</p><p>0</p><p>false</p><p>0</p><p>3</p><p>1ispresent</p><p>0ispresent</p><p>emptyArraylengthis0</p><p>populatedArraylengthis3</p>'
+      },
+      {
         message: 'should evaluate nested <unless> tag in the if (conditionals/unlessNestedIf.html)',
         template: 'conditionals/unlessNestedIf',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),


### PR DESCRIPTION
- Fixed a bug which caused client-side Teddy to handle array length lookups differently from `cheerio`-driven Teddy.
- Fixed a bug which caused client-side Teddy to crash if extra spaces were in markup attribute lists.
- Fixed a bug which caused client-side Teddy to return the wrong data with 2 or more layers of object lookups if the object keys were camelCase.
- Fixed a bug which caused client-side Teddy to rename some form elements accidentally.
- Updated various dependencies.