### PR TITLE
0.6.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next version
 
+## 0.6.21
+
+- Fixed missing exports so you can require/import teddy less verbosely in your projects.
 - Updated docs to clarify what the different builds of Teddy are meant to be used for.
 - Removed minified cjs build since there is no use case for it.
 - Updated various dependencies.

--- a/README.md
+++ b/README.md
@@ -428,16 +428,16 @@ The package is distributed with builds intended for usage in Node.js and separat
 
 For use in Node.js:
 
-- `dist/teddy.cjs`: CommonJS bundle.
-- `dist/teddy.mjs`: ES module.
+- `dist/teddy.cjs`: CommonJS bundle: `const teddy = require('teddy')`
+- `dist/teddy.mjs`: ES module: `import teddy from 'teddy'`
 
 For use in browsers:
 
-- `dist/teddy.client.cjs`: CommonJS bundle.
+- `dist/teddy.client.cjs`: CommonJS bundle: : `const teddy = require('teddy/client')`
 - `dist/teddy.js`: Standalone bundle that can be included via `<script>` tags.
 - `dist/teddy.min.js`: Minified standalone bundle that can be included via `<script>` tags.
-- `dist/teddy.client.mjs`: ES module.
-- `dist/teddy.min.mjs`: Minified ES module.
+- `dist/teddy.client.mjs`: ES module: `import teddy from 'teddy/client'`
+- `dist/teddy.min.mjs`: Minified ES module: `import teddy from 'teddy/client/min'`
 
 Once Teddy is included in your app, you can then pass source code to Teddy's render method, like so: `teddy.render(sourceCode, yourModel)`. The render method will return a fully rendered template. See [API documentation](https://github.com/rooseveltframework/teddy#api) for more information about the Teddy API.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teddy",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teddy",
-      "version": "0.6.20",
+      "version": "0.6.21",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cheerio": "1.0.0"
@@ -515,9 +515,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
-      "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
+      "version": "22.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1329,9 +1329,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001696",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
-      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
+      "version": "1.0.30001697",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
+      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
       "dev": true,
       "funding": [
         {
@@ -1909,9 +1909,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.90",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.90.tgz",
-      "integrity": "sha512-C3PN4aydfW91Natdyd449Kw+BzhLmof6tzy5W1pFC5SpQxVXT+oyiyOG9AgYYSN9OdA/ik3YkCrpwqI8ug5Tug==",
+      "version": "1.5.91",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz",
+      "integrity": "sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -3858,13 +3858,13 @@
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
-      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5498,9 +5498,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/teddy/graphs/contributors"
     }
   ],
-  "version": "0.6.20",
+  "version": "0.6.21",
   "files": [
     "dist"
   ],
@@ -17,6 +17,13 @@
     ".": {
       "import": "./dist/teddy.mjs",
       "require": "./dist/teddy.cjs"
+    },
+    "./client": {
+      "import": "./dist/teddy.client.mjs",
+      "require": "./dist/teddy.client.cjs"
+    },
+    "./client/min": {
+      "import": "./dist/teddy.min.mjs"
     }
   },
   "homepage": "https://github.com/rooseveltframework/teddy",


### PR DESCRIPTION
- Fixed missing exports so you can require/import teddy less verbosely in your projects.
- Updated docs to clarify what the different builds of Teddy are meant to be used for.
- Removed minified cjs build since there is no use case for it.
- Updated various dependencies.