### PR TITLE
0.6.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Next version
 
+## 0.6.22
+
+- Made variable name lookups case insensitive in server-side Teddy to match client-side Teddy so as to match HTML grammar rules.
+- Added some performance improvements to loops and includes.
+- Fixed a bug preventing `<noparse>` and `<noteddy>` tags from working in markup passed to include tags.
+- Updated various dependencies.
+
 ## 0.6.21
 
 - Fixed missing exports so you can require/import teddy less verbosely in your projects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 ## 0.6.14
 
-- Finsihed work on `cheerioPolyfill.js` which makes it possible for Teddy to execute in client-side contexts without using `cheerio`, allowing for a very small bundle size for client-side Teddy (17kb minified).
+- Finished work on `cheerioPolyfill.js` which makes it possible for Teddy to execute in client-side contexts without using `cheerio`, allowing for a very small bundle size for client-side Teddy (17kb minified).
 - Fixed client-side tests to test Teddy in the browser properly.
 - Refactored tests to improve maintainability.
 - Updated various dependencies.
@@ -212,7 +212,7 @@
 - Variables with spaces in them will now be parsed.
 - Fixed issue where one line if statements couldn't use variables as part of the condition.
 - Fixed issue where recursive variable resolution could cause an infinite loop.
-- Signifcant performance improvements.
+- Significant performance improvements.
 - Total rewrite into a much cleaner codebase:
   - Less reliance on regex and more reliance on character counting in base algorithm.
   - Code now split into separate files for development but bundled into a single JS file with Webpack during deployment.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Variables
 
 Display a variable by simply writing `{varName}` anywhere in the template.
 
+All variable names are case-insensitive, both in `{varName}` form and when referenced in Teddy tags described below. This is to comply with the rules of HTML grammar which mandate that HTML tags and attributes be case insensitive.
+
 HTML entities such as `<`, `>`, `&`, `'`, and `"` will be escaped by default as a safeguard against [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting).
 
 If you need to suppress this escaping in certain scenarios, write your variable like this: `{varName|s}`.
@@ -147,7 +149,6 @@ Pass arguments to the template:
 ```
 
 The arguments you've defined will be accessible as `{firstArgument}` and `{secondArgument|s}` in the child template `partial.html`. Note you must use the `|s` flag to suppress escaping HTML entities in order to render the HTML in the second argument.
-
 
 Conditionals
 ---
@@ -477,10 +478,10 @@ API
 
 - `teddy.setVerbosity(n)`: Sets the level of verbosity in Teddy's console logs. Call `teddy.setVerbosity(n)` where `n` equals one of the below values to change the default:
 
-  - `0`: No logging.
-  - `1`: The default. Concise logging. Will usually only log serious errors.
-  - `2`: Verbose logging. Logs even minor errors.
-  - `3`: Debug mode. Very verbose.
+  - `0` or `'none'`: No logging.
+  - `1` or `'concise'`: The default. Concise logging. Will usually only log serious errors.
+  - `2` or `'verbose'`: Verbose logging. Logs even minor errors.
+  - `3`, `'debug'`, or `'DEBUG'`: Debug mode. Very verbose.
 
 - `teddy.setDefaultParams()`: Reset all params to default.
 
@@ -524,7 +525,6 @@ API
     - `template`: Name of the template to delete the cache of.
     - `key`: Model variable cache index to delete it by.
       - If `key` is not provided, it will delete all caches of that template.
-
 
 Hacking the code
 ===

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 Teddy templating engine
 ===
 
@@ -15,9 +14,9 @@ It uses HTML-like `<tags>` for rudimentary templating logic and Teddy Roosevelt'
 
 ![Teddy Roosevelt's facial hair is a curly brace.](https://github.com/rooseveltframework/generator-roosevelt/blob/main/generators/app/templates/statics/images/teddy.jpg "Teddy Roosevelt's facial hair is a curly brace.")
 
-
 Table of contents
 ===
+
 - [Why yet another templating engine?](https://github.com/rooseveltframework/teddy#why-yet-another-templating-engine)
   - [Other popular templating engines are too cryptic](https://github.com/rooseveltframework/teddy#other-popular-templating-engines-are-too-cryptic)
 - [Teddy, symbol-buster extraordinaire](https://github.com/rooseveltframework/teddy#teddy-symbol-buster-extraordinaire)
@@ -41,7 +40,6 @@ Why yet another templating engine?
 Good question.
 
 Here's why:
-
 
 Other popular templating engines are too cryptic
 ---
@@ -86,7 +84,6 @@ Want something simpler and more readable so you can stop wasting time memorizing
 
 Well you're not the only one.
 
-
 Teddy, symbol-buster extraordinaire
 ===
 
@@ -102,12 +99,10 @@ Here's how:
 - A `<loop>` tag for looping.
 - Server-side `{! comments !}` delimited by exclamation points in a fashion similar to `<!-- HTML comments -->`. Server-side comments are stripped out at the template compilation stage.
 
-
 How to write Teddy templates
 ===
 
 Here's some examples of how to write Teddy templates:
-
 
 Variables
 ---
@@ -128,19 +123,19 @@ Includes
 Include another template:
 
 ```html
-<include src='partial.html'></include>
+<include src="partial.html"></include>
 ```
 
 Or use the no extension shorthand (Teddy will append the `.html` extension for you):
 
 ```html
-<include src='partial'></include>
+<include src="partial"></include>
 ```
 
 Pass arguments to the template:
 
 ```html
-<include src='partial.html'>
+<include src="partial.html">
   <arg firstArgument>Plain text argument</arg>
   <arg secondArgument>
     <span>Argument with HTML in it</span>
@@ -167,7 +162,7 @@ Check for the presence of a variable:
 Check a variable's value:
 
 ```html
-<if something='hello'>
+<if something="hello">
   <p>The variable 'something' is set to 'hello'</p>
 </if>
 <else>
@@ -214,7 +209,7 @@ An `<unless>` statement structure with an `<elseunless>` tag which is evaluated 
 </else>
 ```
 
-Note: `<if something>` and `<if something=''>` are considered logically equivalent statements in Teddy.
+Note: `<if something>` and `<if something="">` are considered logically equivalent statements in Teddy fjksdfjskd.
 
 Boolean logic
 ---
@@ -264,31 +259,30 @@ One-line ifs
 If you need a more concise conditional to control which attributes are applied to a given element, then use this syntax:
 
 ```html
-<p if-something true="class='shown'" false="class='hidden'">One-line if.</p>
+<p if-something true='class="shown"' false='class="hidden"'>One-line if.</p>
 ```
 
-In that structure, the attribute `if-something` checks to see if the variable `something` is truthy. This means it will check for either variable presence in the model or the boolean value `true`. If so, the class delcared in the `true` attribute is written to the element, resulting in the following output:
+In that structure, the attribute `if-something` checks to see if the variable `something` is truthy. This means it will check for either variable presence in the model or the boolean value `true`. If so, the class declared in the `true` attribute is written to the element, resulting in the following output:
 
 ```html
-<p class='shown'>One-line if.</p>
+<p class="shown">One-line if.</p>
 ```
 
 If not, this will check for non-presence in the model or the boolean value `false`. If so, the class declared in the `false` attribute is written to the element, resulting in the following output:
 
 ```html
-<p class='hidden'>One-line if.</p>
+<p class="hidden">One-line if.</p>
 ```
 
 Like the `<if>` tag you can check for both the presence of a variable as well as its value. To check the value of a variable, use this syntax:
 
 ```html
-<p if-something='hello' true="class='hello'" false="class='not-hello'">One-line if.</p>
+<p if-something="hello" true='class="hello"' false='class="not-hello"'>One-line if.</p>
 ```
 
 It's important to note that whichever type of quotes you use on the outside of your `true` or `false` attributes must be reversed on the inside. So if you use single quotes on the outside, then you must use double quotes on the inside.
 
 Also note you can only have one one-line if statement per element.
-
 
 Loops
 ---
@@ -302,12 +296,12 @@ letters = ['a', 'b', 'c'];
 It can be iterated over like so:
 
 ```html
-<loop through='letters' val='letter'>
+<loop through="letters" val="letter">
   <p>{letter}</p> <!-- outputs a, b, c -->
 </loop>
 ```
 
-In the above example `through='letters'` defines the JS model being iterated over and `val='letter'` defines a local variable for the current `letter` being iterated over.
+In the above example `through="letters"` defines the JS model being iterated over and `val="letter"` defines a local variable for the current `letter` being iterated over.
 
 When looping over more complex data structures, sometimes you will need access to both the key and the value of your array or object. For instance, suppose this JS model:
 
@@ -318,13 +312,13 @@ names = {jack: 'guy', jill: 'girl', hill: 'landscape'};
 It can be iterated over like so:
 
 ```html
-<loop through='names' key='name' val='description'>
+<loop through="names" key="name" val="description">
   <p>{name}</p> <!-- outputs jack, jill, hill -->
   <p>{description}</p> <!-- outputs guy, girl, landscape -->
 </loop>
 ```
 
-We once again define a `through` attribute which we set to `through='names'` and a `val` attribute which we set to `val='description'` similar to the last example. However this time we've iterated over a JS object with named keys instead of a simple indexed array, so it is useful to define a `key` attribute in the `<loop>` tag to gain access to the name of the current iteration variable. We have defined it as `key='name'` in this example.
+We once again define a `through` attribute which we set to `through="names"` and a `val` attribute which we set to `val="description"` similar to the last example. However this time we've iterated over a JS object with named keys instead of a simple indexed array, so it is useful to define a `key` attribute in the `<loop>` tag to gain access to the name of the current iteration variable. We have defined it as `key="name"` in this example.
 
 Even complex, hierarchical data structures can be iterated over. For instance, suppose this JS model:
 
@@ -335,7 +329,7 @@ objects = [{a:1, b:2, c:3}, {a:4, b:5, c:6}, {a:7, b:8, c:9}];
 For the above array of objects, we can combine the techniques illustrated above to display each member of the hierarchy in sequence:
 
 ```html
-<loop through='objects' key='i' val='item'>
+<loop through="objects" key="i" val="item">
   <p>{i}</p> <!-- outputs 0, 1, 2 -->
   <p>{item.a}</p> <!-- outputs 1, 4, 7 -->
   <p>{item.b}</p> <!-- outputs 2, 5, 8 -->
@@ -378,14 +372,20 @@ In the above example, assume that there are a large number of values that `{user
 Here's what the attributes mean:
 
 - `name`: What you want to name your cache. The name is necessary so you can manually clear the cache from JavaScript later if you like via `teddy.clearCache(name, keyVal)`.
+
   - `teddy.clearCache(name)` will delete the whole cache at that name, e.g. all values for `{city}`.
   - `teddy.clearCache(name, keyVal)` will delete just the value at that keyVal, e.g. just the cache for when `{city}` resolves to NY if you set keyVal to NY.
+
 - `key`: The model value to use to index new caches.
+
   - Example: Suppose `city` in the above example could resolve to three possible values: NY, SF, and LA. In that case, the caching feature will create 3 caches using the `city` key: one for each of the three possible values.
+
 - `maxAge`: How old the cache can be in milliseconds before it is invalidated and will be re-rendered.
+
   - Default: 0 (no limit).
 
 - `maxCaches`: The maximum number of caches that Teddy will be allowed to create for a given `<cache>` element. If the maximum is reached, Teddy will remove the oldest cache in the stack, where oldest is defined as the least recently created *or* accessed.
+
   - Default: 1000.
 
 You can also cache whole templates. For more details about that, see the API docs below.
@@ -402,12 +402,12 @@ objects = [{a:1, b:2, c:3}, {a:4, b:5, c:6}, {a:7, b:8, c:9}];
 We could perform many complex operations simultaneously. For instance, we could iterate over it with a `<loop>` and then at each iteration perform an `<if>` statement and `<include>` a partial:
 
 ```html
-<loop through='objects' val='item'>
-  <if item.a='4'>
+<loop through="objects" val="item">
+  <if item.a="4">
     <p>item.a is 4</p>
   </if>
-  <p if-item.b='5' true="class='item-b-is-five'" false='hidden'>item.b is 5</p>
-  <include src='partial.html'>
+  <p if-item.b="5" true='class="item-b-is-five"' false="hidden">item.b is 5</p>
+  <include src="partial.html">
     <arg firstArgument>{item.b}</arg>
     <arg secondArgument>
       <span>{item.c}</span>
@@ -475,6 +475,7 @@ API
     - ```javascript
       const templateFunction = teddy.compile('<p>{hello}</p>')
       templateFunction({ hello: 'world' }) // returns "<p>world</p>"
+      ```
 
 - `teddy.setVerbosity(n)`: Sets the level of verbosity in Teddy's console logs. Call `teddy.setVerbosity(n)` where `n` equals one of the below values to change the default:
 
@@ -486,9 +487,11 @@ API
 - `teddy.setDefaultParams()`: Reset all params to default.
 
 - `teddy.maxPasses(n)`: Sets the maximum number of passes the parser can execute over your template. If this maximum is exceeded, Teddy will stop attempting to render the template. The limit exists to prevent the possibility of teddy producing infinite loops due to improperly coded templates.
+
   - Default: 1000.
 
 - `teddy.setEmptyVarBehavior('hide')`: Will make it possible for variables which don't resolve to display as empty strings instead of displaying the variable.
+
   - Default: 'display'.
 
 - `teddy.setCache(params)`: Declare a template-level cache.
@@ -496,13 +499,17 @@ API
   - Params:
 
     - `template`: Name of the template to cache.
+
     - `key`: Model variable to cache it by.
+
       - Set to `none` to cache the first render for all model values.
 
     - `maxAge`: How old the cache can be in milliseconds before it is invalidated and will be re-rendered.
+
       - Default: 0 (no limit).
 
     - `maxCaches`: The maximum number of caches that Teddy will be allowed to create for a given template/key combination. If the maximum is reached, Teddy will remove the oldest cache in the stack, where oldest is defined as the least recently created *or* accessed.
+
       - Default: 1000.
       - Note: does not apply to caches where `key` is not also set.
 
@@ -514,6 +521,7 @@ API
         key: 'city',
         maxAge: 1000
       })
+      ```
 
 - `teddy.clearCache(name)`: If `name` is a string, it will delete the whole cache at that name.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teddy",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teddy",
-      "version": "0.6.21",
+      "version": "0.6.22",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cheerio": "1.0.0"
@@ -16,13 +16,13 @@
         "c8": "10.1.3",
         "codecov": "3.8.3",
         "cross-env": "7.0.3",
-        "eslint": "9.19.0",
+        "eslint": "9.21.0",
         "eslint-plugin-html": "8.1.2",
         "eslint-plugin-mocha": "10.5.0",
         "mocha": "11.1.0",
         "standard": "17.1.2",
         "terser-webpack-plugin": "5.3.11",
-        "webpack": "5.97.1",
+        "webpack": "5.98.0",
         "webpack-cli": "6.0.1"
       },
       "engines": {
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -167,9 +167,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
-      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
+      "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -187,13 +187,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
-      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -277,9 +277,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -515,9 +515,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
-      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
+      "version": "22.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -847,16 +847,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -1275,9 +1265,9 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1329,9 +1319,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001697",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
-      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
+      "version": "1.0.30001700",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
       "dev": true,
       "funding": [
         {
@@ -1909,9 +1899,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.91",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz",
-      "integrity": "sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==",
+      "version": "1.5.103",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.103.tgz",
+      "integrity": "sha512-P6+XzIkfndgsrjROJWfSvVEgNHtPgbhVyTkwLjUM2HU/h7pZRORgaTlHqfAikqxKmdJMLW8fftrdGWbd/Ds0FA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1936,9 +1926,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
-      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2135,13 +2125,16 @@
       }
     },
     "node_modules/es-shim-unscopables": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
-      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-to-primitive": {
@@ -2186,22 +2179,22 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.19.0.tgz",
-      "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.21.0.tgz",
+      "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.10.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.19.0",
-        "@eslint/plugin-kit": "^0.2.5",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.21.0",
+        "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -2848,16 +2841,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/for-each": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.4.tgz",
-      "integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2961,18 +2954,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -3511,13 +3504,13 @@
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -4490,9 +4483,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5041,9 +5034,9 @@
       }
     },
     "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6393,9 +6386,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
-      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6771,9 +6764,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.97.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
-      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
+      "version": "5.98.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
+      "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6795,9 +6788,9 @@
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
+        "schema-utils": "^4.3.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.10",
+        "terser-webpack-plugin": "^5.3.11",
         "watchpack": "^2.4.1",
         "webpack-sources": "^3.2.3"
       },
@@ -6917,25 +6910,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/teddy/graphs/contributors"
     }
   ],
-  "version": "0.6.21",
+  "version": "0.6.22",
   "files": [
     "dist"
   ],
@@ -41,13 +41,13 @@
     "c8": "10.1.3",
     "codecov": "3.8.3",
     "cross-env": "7.0.3",
-    "eslint": "9.19.0",
+    "eslint": "9.21.0",
     "eslint-plugin-html": "8.1.2",
     "eslint-plugin-mocha": "10.5.0",
     "mocha": "11.1.0",
     "standard": "17.1.2",
     "terser-webpack-plugin": "5.3.11",
-    "webpack": "5.97.1",
+    "webpack": "5.98.0",
     "webpack-cli": "6.0.1"
   },
   "standard": {

--- a/test/templates/misc/markupArgumentWithNoParseTemplateLiterals.html
+++ b/test/templates/misc/markupArgumentWithNoParseTemplateLiterals.html
@@ -1,0 +1,9 @@
+{!
+  should render variable markup but should not parse any code in <noparse> tags
+!}
+
+{something|s}
+<noparse>
+  <p>${escapeTest}</p>
+  <p class="${escapeTest}">hello</p>
+</noparse>

--- a/test/templates/misc/varForceEmptyDisplay.html
+++ b/test/templates/misc/varForceEmptyDisplay.html
@@ -1,0 +1,5 @@
+{!
+  should force display missing variables and display the variable {missing|d} but remove |d
+!}
+
+<p>{missing|d}</p>

--- a/test/templates/misc/varForceEmptyHide.html
+++ b/test/templates/misc/varForceEmptyHide.html
@@ -1,0 +1,5 @@
+{!
+  should force hide missing variables and treat them as empty strings {missing|h}
+!}
+
+<p>{missing|h}</p>

--- a/test/templates/misc/varNoParsing2.html
+++ b/test/templates/misc/varNoParsing2.html
@@ -1,0 +1,9 @@
+{!
+  should not parse any code in <noparse> tags
+!}
+
+<include src='misc/markupArgumentWithNoParseTemplateLiterals'>
+  <arg something>
+    <p>hello</p>
+  </arg>
+</include>

--- a/test/tests.js
+++ b/test/tests.js
@@ -918,10 +918,30 @@ export default [
         expected: '<div><span>raw html</span></div>'
       },
       {
+        message: 'should force hide missing variables and treat them as empty strings {missing|h} (misc/varForceEmptyHide.html)',
+        template: 'misc/varForceEmptyHide',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p></p>',
+        skip: true
+      },
+      {
+        message: 'should force display missing variables and display the variable {missing|d} but remove |d (misc/varForceEmptyDisplay.html)',
+        template: 'misc/varForceEmptyDisplay',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p>{missing}</p>',
+        skip: true
+      },
+      {
         message: 'should not parse any code in <noteddy> tags (misc/varNoParsing.html)',
         template: 'misc/varNoParsing',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
         expected: '<p>{escapeTest}</p>'
+      },
+      {
+        message: 'should not parse any code in <noparse> tags (misc/varNoParsing2.html)',
+        template: 'misc/varNoParsing2',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p>hello</p><p>${escapeTest}</p><p class="${escapeTest}">hello</p>' // eslint-disable-line
       },
       {
         message: 'should remove {! server side comments !} (misc/serverSideComments.html)',
@@ -950,7 +970,7 @@ export default [
       {
         message: 'should render plain HTML with no teddy tags with no changes (misc/plainHTML.html)',
         template: 'misc/plainHTML',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        run: async (teddy, template, model, assert, expected) => {
           const teddyTemplate = teddy.render(template, model)
 
           assert(teddyTemplate, '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="format-detection" content="telephone=no"><title>Plain HTML</title><link rel="stylesheet" href="/css/styles.css"></head><body><main><p>This template contains no teddy tags. Just HTML.</p></main><script type="text/javascript" src="/js/main.js"></script></body></html>')


### PR DESCRIPTION
- Made variable name lookups case insensitive in server-side Teddy to match client-side Teddy so as to match HTML grammar rules.
- Added some performance improvements to loops and includes.
- Fixed a bug preventing `<noparse>` and `<noteddy>` tags from working in markup passed to include tags.
- Updated various dependencies.