### PR TITLE
0.6.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Next version
 
+- Put your changes here...
+
+## 0.6.23
+
+- Added new `<inline>` tag for adding inline CSS or JS using Teddy variables. Usage is optional, but it can help you avoid syntax error warnings in your code editor.
+- Fixed a bug preventing `<include>` args from parsing correctly in certain circumstances.
+- Updated various dependencies.
+
 ## 0.6.22
 
 - Made variable name lookups case insensitive in server-side Teddy to match client-side Teddy so as to match HTML grammar rules.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Here's some examples of how to write Teddy templates:
 Variables
 ---
 
-Display a variable by simply writing `{varName}` anywhere in the template.
+Display a variable by simply writing `{varName}` anywhere in the template. You can also use template literal `${templateLiteral}` variables as well.
 
 All variable names are case-insensitive, both in `{varName}` form and when referenced in Teddy tags described below. This is to comply with the rules of HTML grammar which mandate that HTML tags and attributes be case insensitive.
 
@@ -115,7 +115,23 @@ HTML entities such as `<`, `>`, `&`, `'`, and `"` will be escaped by default as 
 
 If you need to suppress this escaping in certain scenarios, write your variable like this: `{varName|s}`.
 
-You can also use template literal `${templateLiteral}` variables as well.
+### A note about inline CSS or JS via Teddy variables
+
+If you want to pass inline CSS or JS code to a `<style>` or `<script>` tag via a Teddy variable, you can do so like this:
+
+```html
+<style>{inlineStyles|s}</style>
+<script>{inlineScript|s}</script>
+```
+
+That will work, but your code editor may complain that this is a syntax error. To avoid that, Teddy also provides a convenience tag called `<inline>` to let you do it like this instead:
+
+```html
+<inline css="inlineStyles"></inline>
+<inline js="inlineScript"></inline>
+```
+
+The `<inline>` tag approach will work the same as the previous examples using `<style>` or `<script>` tags manually, but code editors will not consider it a syntax error.
 
 Includes
 ---

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Teddy templating engine
 ===
 
 [![Build Status](https://github.com/rooseveltframework/teddy/workflows/CI/badge.svg
-)](https://github.com/rooseveltframework/teddy/actions?query=workflow%3ACI) [![codecov](https://codecov.io/gh/rooseveltframework/teddy/branch/master/graph/badge.svg)](https://codecov.io/gh/rooseveltframework/teddy) [![npm](https://img.shields.io/npm/v/teddy.svg)](https://www.npmjs.com/package/teddy)
+)](https://github.com/rooseveltframework/teddy/actions?query=workflow%3ACI) [![npm](https://img.shields.io/npm/v/teddy.svg)](https://www.npmjs.com/package/teddy)
 
 Teddy is the most readable and easy to learn templating language there is!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teddy",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teddy",
-      "version": "0.6.22",
+      "version": "0.6.23",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cheerio": "1.0.0"
@@ -868,9 +868,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
-      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+      "version": "22.13.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
+      "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/teddy/graphs/contributors"
     }
   ],
-  "version": "0.6.22",
+  "version": "0.6.23",
   "files": [
     "dist"
   ],

--- a/test/model.js
+++ b/test/model.js
@@ -100,6 +100,8 @@ export default function makeModel () {
     teddyNull: null,
     valWithQuotes: '"hi there!"',
     specialChars: 'special .$&@. chars',
+    inlineStyles: 'body { font-family: sans-serif; }',
+    inlineScript: 'console.log("hello")',
     complexJSONString: '{"content":{"appTitle":"Some App","pageTitle":"{content.appTitle}"},"currentYear":1858,"mainDomain":"localhost:43711","NODE_ENV":"development"}',
     obj: {
       one: {

--- a/test/templates/includes/includeArgCheckedByOneLineIfPartialCaseInsensitive.html
+++ b/test/templates/includes/includeArgCheckedByOneLineIfPartialCaseInsensitive.html
@@ -1,0 +1,5 @@
+{!
+  when included by includeArgCheckedByOneLineIfWrapperCaseInsensitive.html, the class should render
+!}
+
+<p if-totallyUniqueArg true='class="{totallyUniqueArg}"'>Is it populated? {totallyUniqueArg}</p>

--- a/test/templates/includes/includeArgCheckedByOneLineIfWrapperCaseInsensitive.html
+++ b/test/templates/includes/includeArgCheckedByOneLineIfWrapperCaseInsensitive.html
@@ -1,0 +1,7 @@
+{!
+  should populate <include> <arg> in the child template
+!}
+
+<include src='includes/includeArgCheckedByOneLineIfPartialCaseInsensitive.html'>
+  <arg totallyUniqueArg>populated</arg>
+</include>

--- a/test/templates/misc/inlineTag.html
+++ b/test/templates/misc/inlineTag.html
@@ -1,0 +1,8 @@
+{!
+  should render <inline> tags
+!}
+
+<div>
+  <inline css="inlineStyles"></inline>
+  <inline js="inlineScript"></inline>
+</div>

--- a/test/tests.js
+++ b/test/tests.js
@@ -494,6 +494,12 @@ export default [
         expected: '<p class="populated">Is it populated? populated</p>'
       },
       {
+        message: 'should populate case insensitive <include> <arg> in the child template; the class should render (includes/includeArgCheckedByOneLineIfWrapperCaseInsensitive.html)',
+        template: 'includes/includeArgCheckedByOneLineIfWrapperCaseInsensitive',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p class="populated">Is it populated? populated</p>'
+      },
+      {
         message: 'should <include> a template with arguments (includes/includeWithArguments.html)',
         template: 'includes/includeWithArguments',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
@@ -930,6 +936,12 @@ export default [
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
         expected: '<p>{missing}</p>',
         skip: true
+      },
+      {
+        message: 'should render <inline> tags (misc/inlineTag.html)',
+        template: 'misc/inlineTag',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<div><style>body{font-family:sans-serif;}</style><script>console.log("hello")</script></div>'
       },
       {
         message: 'should not parse any code in <noteddy> tags (misc/varNoParsing.html)',


### PR DESCRIPTION
- Added new `<inline>` tag for adding inline CSS or JS using Teddy variables. Usage is optional, but it can help you avoid syntax error warnings in your code editor.
- Fixed a bug preventing `<include>` args from parsing correctly in certain circumstances.
- Updated various dependencies.