### PR TITLE
0.6.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 - Put your changes here...
 
+## 0.6.24
+
+- Added `{varName|h}` to force hide or `{varName|d}` to force display variable. This is a per-var override for:
+  - `teddy.setEmptyVarBehavior('hide')`: Will make it possible for variables which don't resolve to display as empty strings instead of displaying the variable.
+    - Default: 'display'.
+- Added support for sourcing most Teddy attribute values dynamically from `{variables}`.
+- Added boolean logic to one-line if statements.
+- Added `selected-value` and `checked-value` attributes for setting what option to select or what checkbox / radio to check in a more concise way than using one-line ifs.
+- Fixed a bug that prevented boolean logic from working if there were multiple `and` or multiple `or` attributes on an element.
+- Updated various dependencies.
+
 ## 0.6.23
 
 - Added new `<inline>` tag for adding inline CSS or JS using Teddy variables. Usage is optional, but it can help you avoid syntax error warnings in your code editor.

--- a/README.md
+++ b/README.md
@@ -14,26 +14,6 @@ It uses HTML-like `<tags>` for rudimentary templating logic and Teddy Roosevelt'
 
 ![Teddy Roosevelt's facial hair is a curly brace.](https://github.com/rooseveltframework/generator-roosevelt/blob/main/generators/app/templates/statics/images/teddy.jpg "Teddy Roosevelt's facial hair is a curly brace.")
 
-Table of contents
-===
-
-- [Why yet another templating engine?](https://github.com/rooseveltframework/teddy#why-yet-another-templating-engine)
-  - [Other popular templating engines are too cryptic](https://github.com/rooseveltframework/teddy#other-popular-templating-engines-are-too-cryptic)
-- [Teddy, symbol-buster extraordinaire](https://github.com/rooseveltframework/teddy#teddy-symbol-buster-extraordinaire)
-- [How to write Teddy templates](https://github.com/rooseveltframework/teddy#how-to-write-teddy-templates)
-  - [Variables](https://github.com/rooseveltframework/teddy#variables)
-  - [Includes](https://github.com/rooseveltframework/teddy#includes)
-  - [Conditionals](https://github.com/rooseveltframework/teddy#conditionals)
-  - [Boolean logic](https://github.com/rooseveltframework/teddy#boolean-logic)
-  - [One-line ifs](https://github.com/rooseveltframework/teddy#one-line-ifs)
-  - [Loops](https://github.com/rooseveltframework/teddy#loops)
-  - [Non-parsed-blocks](https://github.com/rooseveltframework/teddy#non-parsed-blocks)
-  - [Caching blocks](https://github.com/rooseveltframework/teddy#caching-blocks)
-  - [A complex example combining many tags](https://github.com/rooseveltframework/teddy#a-complex-example-combining-many-tags)
-- [Usage](https://github.com/rooseveltframework/teddy#usage)
-- [API](https://github.com/rooseveltframework/teddy#api)
-- [Hacking the code](https://github.com/rooseveltframework/teddy#hacking-the-code)
-
 Why yet another templating engine?
 ===
 
@@ -353,6 +333,52 @@ For the above array of objects, we can combine the techniques illustrated above 
 </loop>
 ```
 
+## Selecting option elements, checkboxes, or radio buttons
+
+You could use a one-line if to select `<option>` elements inside of `<select>` fields, or to select checkboxes / radio buttons like this:
+
+```html
+<select>
+  <option value="a" if-foo="a" true="selected">A</option>
+  <option value="b" if-foo="b" true="selected">B</option>
+  <option value="c" if-foo="c" true="selected">C</option>
+</select>
+```
+
+However that is tedious.
+
+Teddy also provides a convenience attribute `selected-value` to automate this process so you can write it like this:
+
+```html
+<select selected-value="b">
+  <option value="a">A</option>
+  <option value="b">B</option> <!-- this will be selected -->
+  <option value="c">C</option>
+</select>
+```
+
+This also works with checkboxes and radio buttons using `checked-value`:
+
+```html
+<div checked-value="b">
+  <input type="checkbox" name="letters" value="a">
+  <input type="checkbox" name="letters" value="b"> <!-- this will be selected -->
+  <input type="checkbox" name="letters" value="c">
+</div>
+
+<div checked-value="b">
+  <input type="radio" name="letters" value="a">
+  <input type="radio" name="letters" value="b"> <!-- this will be selected -->
+  <input type="radio" name="letters" value="c">
+</div>
+
+<div checked-value="b" checked-value="c">
+  <input type="checkbox" name="letters" value="a">
+  <input type="checkbox" name="letters" value="b"> <!-- this will be selected -->
+  <input type="checkbox" name="letters" value="c"> <!-- this will be selected -->
+</div>
+```
+
 ## Non-parsed blocks
 
 To skip teddy parsing a block of code, use a `<noteddy>` or `<noparse>` tag:
@@ -388,20 +414,20 @@ In the above example, assume that there are a large number of values that `{user
 Here's what the attributes mean:
 
 - `name`: What you want to name your cache. The name is necessary so you can manually clear the cache from JavaScript later if you like via `teddy.clearCache(name, keyVal)`.
-
+  
   - `teddy.clearCache(name)` will delete the whole cache at that name, e.g. all values for `{city}`.
   - `teddy.clearCache(name, keyVal)` will delete just the value at that keyVal, e.g. just the cache for when `{city}` resolves to NY if you set keyVal to NY.
 
 - `key`: The model value to use to index new caches.
-
+  
   - Example: Suppose `city` in the above example could resolve to three possible values: NY, SF, and LA. In that case, the caching feature will create 3 caches using the `city` key: one for each of the three possible values.
 
 - `maxAge`: How old the cache can be in milliseconds before it is invalidated and will be re-rendered.
-
+  
   - Default: 0 (no limit).
 
 - `maxCaches`: The maximum number of caches that Teddy will be allowed to create for a given `<cache>` element. If the maximum is reached, Teddy will remove the oldest cache in the stack, where oldest is defined as the least recently created *or* accessed.
-
+  
   - Default: 1000.
 
 You can also cache whole templates. For more details about that, see the API docs below.
@@ -476,25 +502,25 @@ API
 - `teddy.setTemplate(name, template)`: Add a new template to the template cache.
 
 - `teddy.render(template, model)`: Render a template by supplying either source code or a file name (in Node.js).
-
+  
   - Returns fully rendered HTML.
   - Removes `{! teddy comments !}`
 
 - `teddy.setTemplateRoot(path)`: Set the location of your templates directory.
-
+  
   - Default is the current directory.
 
 - `teddy.compile(templateString)`: Takes a template string and returns a function which when given model data will render HTML from the template and model data.
-
+  
   - e.g.
-
+    
     - ```javascript
       const templateFunction = teddy.compile('<p>{hello}</p>')
       templateFunction({ hello: 'world' }) // returns "<p>world</p>"
       ```
 
 - `teddy.setVerbosity(n)`: Sets the level of verbosity in Teddy's console logs. Call `teddy.setVerbosity(n)` where `n` equals one of the below values to change the default:
-
+  
   - `0` or `'none'`: No logging.
   - `1` or `'concise'`: The default. Concise logging. Will usually only log serious errors.
   - `2` or `'verbose'`: Verbose logging. Logs even minor errors.
@@ -503,34 +529,36 @@ API
 - `teddy.setDefaultParams()`: Reset all params to default.
 
 - `teddy.maxPasses(n)`: Sets the maximum number of passes the parser can execute over your template. If this maximum is exceeded, Teddy will stop attempting to render the template. The limit exists to prevent the possibility of teddy producing infinite loops due to improperly coded templates.
-
+  
   - Default: 1000.
 
 - `teddy.setEmptyVarBehavior('hide')`: Will make it possible for variables which don't resolve to display as empty strings instead of displaying the variable.
-
+  
   - Default: 'display'.
+  
+  - Override this behavior on a per variable basis by using `{varName|h}` to force it to hide or `{varName|d}` to force it to display.
 
 - `teddy.setCache(params)`: Declare a template-level cache.
-
+  
   - Params:
-
+    
     - `template`: Name of the template to cache.
-
+    
     - `key`: Model variable to cache it by.
-
+      
       - Set to `none` to cache the first render for all model values.
-
+    
     - `maxAge`: How old the cache can be in milliseconds before it is invalidated and will be re-rendered.
-
+      
       - Default: 0 (no limit).
-
+    
     - `maxCaches`: The maximum number of caches that Teddy will be allowed to create for a given template/key combination. If the maximum is reached, Teddy will remove the oldest cache in the stack, where oldest is defined as the least recently created *or* accessed.
-
+      
       - Default: 1000.
       - Note: does not apply to caches where `key` is not also set.
-
+  
   - Example:
-
+    
     - ```javascript
       teddy.setCache({
         template: 'someTemplate.html',
@@ -544,7 +572,7 @@ API
 - `teddy.clearCache(name, keyVal)`: Deletes just the value at that keyVal. Assumes `name` will be a string.
 
 - `teddy.clearCache(params)`: If `params` is an object, it will delete a whole template-level cache.
-
+  
   - Params:
     - `template`: Name of the template to delete the cache of.
     - `key`: Model variable cache index to delete it by.

--- a/cheerioPolyfill.js
+++ b/cheerioPolyfill.js
@@ -20,6 +20,11 @@ export function load (html) {
         return el.childNodes
       },
 
+      // e.g. dom(el).find() from teddy
+      find: function (selector) {
+        return el.querySelectorAll(selector)
+      },
+
       // e.g. dom(arg).html() from teddy
       html: function () {
         return getTeddyDOMInnerHTML(el)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teddy",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teddy",
-      "version": "0.6.23",
+      "version": "0.6.24",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cheerio": "1.0.0"
@@ -868,9 +868,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
-      "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
+      "version": "22.13.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
+      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1705,14 +1705,14 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1742,9 +1742,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001701",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
-      "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
+      "version": "1.0.30001702",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz",
+      "integrity": "sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==",
       "dev": true,
       "funding": [
         {
@@ -2331,9 +2331,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.109",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.109.tgz",
-      "integrity": "sha512-AidaH9JETVRr9DIPGfp1kAarm/W6hRJTPuCnkF+2MqhF4KaAgRIcBc8nvjk+YMXZhwfISof/7WG29eS4iGxQLQ==",
+      "version": "1.5.112",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.112.tgz",
+      "integrity": "sha512-oen93kVyqSb3l+ziUgzIOlWt/oOuy4zRmpwestMn4rhFWAoFJeFuCVte9F2fASjeZZo7l/Cif9TiyrdW4CwEMA==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/teddy/graphs/contributors"
     }
   ],
-  "version": "0.6.23",
+  "version": "0.6.24",
   "files": [
     "dist"
   ],

--- a/test/model.js
+++ b/test/model.js
@@ -22,6 +22,7 @@ export default function makeModel () {
       'three'
     ],
     names: { jack: 'guy', jill: 'girl', hill: 'landscape' },
+    namesVar: 'names',
     nameList: [
       'jack',
       'jill',
@@ -82,6 +83,7 @@ export default function makeModel () {
     dynamicValue: 'Some content',
     somethingMore: 'More content',
     somethingElse: true,
+    lowercaseB: 'b',
     varWithVarInside: 'Variable with a variable inside: {subVar}',
     subVar: 'And another: {something}',
     dynamicInclude: 'misc/variable',

--- a/test/templates/conditionals/ifVariable.html
+++ b/test/templates/conditionals/ifVariable.html
@@ -1,8 +1,8 @@
 {!
-  should evaluate <if something="Some content"> as true
+  should evaluate <if something="{something}"> as true
 !}
 
-<if something="Some content">
+<if something="{something}">
   <p>The variable "something" is set to "Some content"</p>
 </if>
 <else>

--- a/test/templates/conditionals/oneLineBooleanLogic.html
+++ b/test/templates/conditionals/oneLineBooleanLogic.html
@@ -1,0 +1,7 @@
+{!
+  should evaluate one line if boolean logic
+!}
+
+<p if-something and if-nope true="class='something-is-present'" false="class='something-is-not-present'">One line if.</p>
+<p if-nope or if-something true="class='something-is-present'" false="class='something-is-not-present'">One line if.</p>
+<p if-nope or if-alsonope or if-something true="class='something-is-present'" false="class='something-is-not-present'">One line if.</p>

--- a/test/templates/looping/loopKeyValVars.html
+++ b/test/templates/looping/loopKeyValVars.html
@@ -1,0 +1,8 @@
+{!
+  should loop through {namesVar} correctly with key {nameVar} and val {descriptionVar}
+!}
+
+<loop through='{namesVar}' key='name' val='description'>
+  <p>{name}</p> {! outputs jack, jill, hill !}
+  <p>{description}</p> {! outputs guy, girl, landscape !}
+</loop>

--- a/test/templates/looping/selectOptionsAttribOnSelect.html
+++ b/test/templates/looping/selectOptionsAttribOnSelect.html
@@ -1,0 +1,15 @@
+{!
+  should loop through {letters} correctly in a select element using special teddy attribute for select elements to avoid a one-line if
+!}
+
+<select selected-value="b">
+  <loop through='letters' val='letter'>
+    <option value="{letter}">{letter}</option> {! outputs a, b, c !}
+  </loop>
+</select>
+
+<select selected-value="{lowercaseB}">
+  <loop through='letters' val='letter'>
+    <option value="{letter}">{letter}</option> {! outputs a, b, c !}
+  </loop>
+</select>

--- a/test/templates/misc/checkboxRadioCheckedAttrib.html
+++ b/test/templates/misc/checkboxRadioCheckedAttrib.html
@@ -1,0 +1,21 @@
+{!
+  should check checkboxes or radio butons using special teddy attribute to avoid a one-line if
+!}
+
+<div checked-value="b">
+  <input type="checkbox" name="letters" value="a">
+  <input type="checkbox" name="letters" value="b">
+  <input type="checkbox" name="letters" value="c">
+</div>
+
+<div checked-value="b">
+  <input type="radio" name="letters" value="a">
+  <input type="radio" name="letters" value="b">
+  <input type="radio" name="letters" value="c">
+</div>
+
+<div checked-value="b" checked-value="c">
+  <input type="checkbox" name="letters" value="a">
+  <input type="checkbox" name="letters" value="b">
+  <input type="checkbox" name="letters" value="c">
+</div>

--- a/test/tests.js
+++ b/test/tests.js
@@ -25,10 +25,16 @@ export default [
         expected: '<p>The variable \'doesntexist\' is not present</p>'
       },
       {
-        message: 'should evaluate <if something=\'Some content\'> as true (conditionals/ifValue.html)',
+        message: 'should evaluate <if something="Some content"> as true (conditionals/ifValue.html)',
         template: 'conditionals/ifValue',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
-        expected: '<p>The variable \'something\' is set to \'Some content\'</p>'
+        expected: '<p>The variable "something" is set to "Some content"</p>'
+      },
+      {
+        message: 'should evaluate <if something="{something}"> as true (conditionals/ifVariable.html)',
+        template: 'conditionals/ifVariable',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p>The variable "something" is set to "Some content"</p>'
       },
       {
         message: 'should evaluate <if emptyArray> as false (conditionals/ifEmptyArray.html)',
@@ -209,6 +215,12 @@ export default [
         template: 'conditionals/oneLine',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
         expected: '<p class="something-is-present">One line if.</p>'
+      },
+      {
+        message: 'should evaluate one line if "if-something" as true (conditionals/oneLineBooleanLogic.html)',
+        template: 'conditionals/oneLineBooleanLogic',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p class="something-is-not-present">One line if.</p><p class="something-is-present">One line if.</p><p class="something-is-present">One line if.</p>'
       },
       {
         message: 'should evaluate one line if "if-somethingFalse" as false (conditionals/oneLineIfBooleanValue.html)',
@@ -634,6 +646,12 @@ export default [
         expected: '<select><option value="a">a</option><option value="b" selected="selected">b</option><option value="c">c</option></select>'
       },
       {
+        message: 'should loop through {letters} correctly in a select element (looping/selectOptionsAttribOnSelect.html)',
+        template: 'looping/selectOptionsAttribOnSelect',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<select><option value="a">a</option><option value="b" selected="selected">b</option><option value="c">c</option></select><select><option value="a">a</option><option value="b" selected="selected">b</option><option value="c">c</option></select>'
+      },
+      {
         message: 'should loop through {set} correctly (looping/loopValSet.html)',
         template: 'looping/loopValSet',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
@@ -642,6 +660,12 @@ export default [
       {
         message: 'should loop through {names} correctly (looping/loopKeyVal.html)',
         template: 'looping/loopKeyVal',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p>jack</p> <p>guy</p><p>jill</p> <p>girl</p><p>hill</p> <p>landscape</p>'
+      },
+      {
+        message: 'should loop through {namesVar} correctly (looping/loopKeyValVars.html)',
+        template: 'looping/loopKeyValVars',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
         expected: '<p>jack</p> <p>guy</p><p>jill</p> <p>girl</p><p>hill</p> <p>landscape</p>'
       },
@@ -883,6 +907,12 @@ export default [
         expected: '<p id="blah">no blah</p><p id="blah">no blah</p>'
       },
       {
+        message: 'should check checkboxes or radio butons using special teddy attribute to avoid a one-line if (misc/checkboxRadioCheckedAttrib.html)',
+        template: 'misc/checkboxRadioCheckedAttrib',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<div><input type="checkbox" name="letters" value="a"><input type="checkbox" name="letters" value="b" checked="checked"><input type="checkbox" name="letters" value="c"></div><div><input type="radio" name="letters" value="a"><input type="radio" name="letters" value="b" checked="checked"><input type="radio" name="letters" value="c"></div><div><input type="checkbox" name="letters" value="a"><input type="checkbox" name="letters" value="b" checked="checked"><input type="checkbox" name="letters" value="c" checked="checked"></div>'
+      },
+      {
         message: 'should render {variables} as blank when x is true (misc/undefinedVar.html)',
         template: 'misc/undefinedVar',
         run: async (teddy, template, model, assert, expected) => {
@@ -927,15 +957,13 @@ export default [
         message: 'should force hide missing variables and treat them as empty strings {missing|h} (misc/varForceEmptyHide.html)',
         template: 'misc/varForceEmptyHide',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
-        expected: '<p></p>',
-        skip: true
+        expected: '<p></p>'
       },
       {
         message: 'should force display missing variables and display the variable {missing|d} but remove |d (misc/varForceEmptyDisplay.html)',
         template: 'misc/varForceEmptyDisplay',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
-        expected: '<p>{missing}</p>',
-        skip: true
+        expected: '<p>{missing}</p>'
       },
       {
         message: 'should render <inline> tags (misc/inlineTag.html)',


### PR DESCRIPTION
- Added `{varName|h}` to force hide or `{varName|d}` to force display variable. This is a per-var override for:
  - `teddy.setEmptyVarBehavior('hide')`: Will make it possible for variables which don't resolve to display as empty strings instead of displaying the variable.
    - Default: 'display'.
- Added support for sourcing most Teddy attribute values dynamically from `{variables}`.
- Added boolean logic to one-line if statements.
- Added `selected-value` and `checked-value` attributes for setting what option to select or what checkbox / radio to check in a more concise way than using one-line ifs.
- Fixed a bug that prevented boolean logic from working if there were multiple `and` or multiple `or` attributes on an element.
- Updated various dependencies.