### PR TITLE
2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.1
 
 - Fixed a `<loop>` whose `through` names a `{variable}` in the middle of its path, rather than at its head, rendering nothing.
+- Updated dependencies.
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Fixed a `<loop>` whose `through` names a `{variable}` in the middle of its path, rather than at its head, rendering nothing.
+
 ## 2.0.0
 
 - Breaking: Removed support for non-well formed templates. A template, and any markup arriving through the model, now has to be complete on its own.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.1
 
-- Fixed a `<loop>` whose `through` names a `{variable}` in the middle of its path, rather than at its head, rendering nothing.
+- Fixed a `<loop>` whose `through` names a `{variable}` in the middle of its path, rather than at its head, rendering nothing. Fixed the same in the value of a condition: An `<if>`, or a one line `if-`, whose value named a `{variable}` anywhere but at its head was compared against the text as written rather than against what the variable resolved to.
 - Updated dependencies.
 
 ## 2.0.0

--- a/codegen.js
+++ b/codegen.js
@@ -435,9 +435,9 @@ function emitLoop (node, state, out) {
   const keyName = JSON.stringify(node.keyName ?? null)
   const valName = JSON.stringify(node.valName ?? null)
 
-  // a through naming a {variable} is not known until there is a model to read it from, so that one goes through the helper; anything else is a path this code can read directly, which matters for a loop nested inside another whose collection is the outer loop's val
+  // a through naming a {variable} anywhere in its path is not known until there is a model to read it from, so that one goes through the helper; anything else is a path this code can read directly, which matters for a loop nested inside another whose collection is the outer loop's val
   let js = ''
-  if (node.through && node.through.startsWith('{')) {
+  if (node.through && node.through.includes('{')) {
     js += `const ${collection} = r.collection(${JSON.stringify(node.through)}, ${keyName}, ${valName}, ${state.model})\n`
   } else {
     const source = access(node.through, state)

--- a/codegen.js
+++ b/codegen.js
@@ -286,8 +286,8 @@ function armTest (branch, id, index, state) {
     return { setup, test: `${inverted ? '!' : ''}r.present(${values[0]})` }
   }
 
-  // the values above are every lookup the arm makes, so the one thing left that a model could be wanted for is a {variable} standing in for a condition's value, which only the opening arm of a chain resolves
-  const wantsModel = index === 0 && arm.attribs.some(([, value]) => value && value.startsWith('{'))
+  // the values above are every lookup the arm makes, so the one thing left that a model could be wanted for is a {variable} standing in for a condition's value, which only the opening arm of a chain resolves. the variable may sit anywhere in the value, so what counts as one has to be decided the same way conditionArgs decides it, or the model it needs will not have been passed
+  const wantsModel = index === 0 && arm.attribs.some(([, value]) => value && value.includes('{'))
   return { setup, test: `r.arm(r.branches[${id}].arms[${index}], ${wantsModel ? state.model : 'null'}, ${index === 0}, [${values.join(', ')}])` }
 }
 

--- a/compiler.js
+++ b/compiler.js
@@ -250,8 +250,8 @@ export function createCompiler (deps) {
         // split the way the interpreter splits it rather than by length, so an attribute name containing if- more than once is read identically
         const condition = name.split('if-')[1]
         current.argSources.push([condition, value])
-        // a condition whose value is a variable is not known until there is a model to read it from, exactly as for an <if> tag
-        if (value && value.startsWith('{')) current.dynamic = true
+        // a condition whose value names a variable is not known until there is a model to read it from, exactly as for an <if> tag. the variable may sit anywhere in the value rather than at its head, so any brace means the value has to be resolved
+        if (value && value.includes('{')) current.dynamic = true
       } else if (OUTCOMES.has(name)) {
         if (current) current[name === 'true' ? 'ifTrue' : 'ifFalse'] = value.replaceAll('&quot;', '"')
       } else if (JOINERS.has(name)) {
@@ -1013,7 +1013,7 @@ export function createCompiler (deps) {
     for (const [name, value] of argSources) {
       if (value === null) args.push(name)
       else if (!value) args.push(name)
-      else args.push(`${name}=${model && value.startsWith('{') ? parseVars(value, model) : value}`)
+      else args.push(`${name}=${model && value.includes('{') ? parseVars(value, model) : value}`)
     }
     return args
   }
@@ -1023,7 +1023,7 @@ export function createCompiler (deps) {
     for (const [name, raw] of attribs) {
       let value = raw
       if (value) {
-        if (resolveValues && value.startsWith('{')) value = parseVars(value, model)
+        if (resolveValues && value.includes('{')) value = parseVars(value, model)
         args.push(`${name}=${value}`)
       } else args.push(name)
     }

--- a/compiler.js
+++ b/compiler.js
@@ -1053,9 +1053,11 @@ export function createCompiler (deps) {
   }
 
   // what a loop iterates when the name it was pointed at is only known once there is a model to read it from
+  //
+  // a {variable} may sit anywhere in the path rather than at its head, so any brace means the path has to be resolved before it is looked up
   function loopCollection (through, keyName, valName, model) {
     let source = through
-    if (source && source.startsWith('{')) source = parseVars(source, model)
+    if (source && source.includes('{')) source = parseVars(source, model)
     return iterable(source ? getOrSetObjectByDotNotation(model, source) : undefined, keyName, valName)
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teddy",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teddy",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cheerio": "1.2.0"
@@ -1286,9 +1286,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
-      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1328,9 +1328,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -1348,11 +1348,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2038,9 +2038,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.420",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
-      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4847,9 +4847,9 @@
       }
     },
     "node_modules/minimizer-webpack-plugin": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.8.0.tgz",
-      "integrity": "sha512-2cT9+goJfBhtMz+gJqejSf09ClgmYhPhccRb/fb0ztVbixt0BkO8mRuI26FoPPuUNkRk6iEDryWAIouc5W8eJA==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.9.0.tgz",
+      "integrity": "sha512-OASqv+dewv8vjkOBjqMOHvxUaXhtGBLZAXq7JbmYE8TSzBvOswiGq5JcBdc8ypuLL/8YUT1OEyupga6/iqdyTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4870,6 +4870,9 @@
       },
       "peerDependenciesMeta": {
         "@minify-html/node": {
+          "optional": true
+        },
+        "@napi-rs/image": {
           "optional": true
         },
         "@swc/core": {
@@ -4896,10 +4899,19 @@
         "html-minifier-terser": {
           "optional": true
         },
+        "imagemin": {
+          "optional": true
+        },
         "lightningcss": {
           "optional": true
         },
         "postcss": {
+          "optional": true
+        },
+        "sharp": {
+          "optional": true
+        },
+        "svgo": {
           "optional": true
         },
         "uglify-js": {
@@ -7180,9 +7192,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/teddy/graphs/contributors"
     }
   ],
-  "version": "2.0.0",
+  "version": "2.0.1",
   "files": [
     "dist",
     "docs/statics/pages",

--- a/test/model.js
+++ b/test/model.js
@@ -50,6 +50,10 @@ export default function makeModel () {
     arrays: [['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i']],
     missingNumbers: [{ a: undefined, b: undefined, c: undefined }, { a: 4, b: 5, c: 6 }, { a: 7, b: 8, c: 9 }],
     objectOfObjects: { one: { a: 1, b: 2, c: 3 }, two: { a: 4, b: 5, c: 6 }, three: { a: 7, b: 8, c: 9 } },
+    sections: {
+      first: { label: 'First', entries: ['one', 'two'] },
+      second: { label: 'Second', entries: ['three'] }
+    },
     special: {
       number: 2
     },

--- a/test/model.js
+++ b/test/model.js
@@ -87,6 +87,7 @@ export default function makeModel () {
       { name: 'first', active: true, tags: ['a', 'b'] },
       { name: 'second', active: false, tags: ['c'] }
     ],
+    contentWord: 'content',
     something: 'Some content',
     somethingTrue: true,
     somethingFalse: false,

--- a/test/templates/conditionals/conditionalValueVarInMiddle.html
+++ b/test/templates/conditionals/conditionalValueVarInMiddle.html
@@ -1,0 +1,10 @@
+{!
+  should evaluate <if something='Some {contentWord}'> as true, with the variable in the middle of the value
+!}
+
+<if something='Some {contentWord}'>
+  <p>true</p>
+</if>
+<else>
+  <p>false</p>
+</else>

--- a/test/templates/conditionals/oneLineValueVarInMiddle.html
+++ b/test/templates/conditionals/oneLineValueVarInMiddle.html
@@ -1,0 +1,5 @@
+{!
+  should evaluate one line if "if-something" whose value names a {variable} in the middle
+!}
+
+<p if-something='Some {contentWord}' true='class="matched"' false='class="unmatched"'>{something}</p>

--- a/test/templates/looping/loopThroughWithVarInPath.html
+++ b/test/templates/looping/loopThroughWithVarInPath.html
@@ -1,0 +1,10 @@
+{!
+  should render the body of a nested loop whose through names a {variable} from the enclosing loop in the middle of its path
+!}
+
+<loop through="sections" key="sectionKey" val="section">
+  <p id="{sectionKey}">{section.label}</p>
+  <loop through="sections.{sectionKey}.entries" val="entry">
+    <span>{entry}</span>
+  </loop>
+</loop>

--- a/test/tests.js
+++ b/test/tests.js
@@ -794,6 +794,13 @@ export default [
         expected: '<p>guy</p><p>girl</p><p>landscape</p><p>man</p><p>woman</p><p>scenary</p>'
       },
       {
+        // a through whose middle segment is a {variable} from the enclosing loop is only known once there is a model to read it from, so the loop must resolve the variable before it looks up the path
+        message: 'should render the body of a nested loop whose through names a {variable} from the enclosing loop in the middle of its path (looping/loopThroughWithVarInPath.html)',
+        template: 'looping/loopThroughWithVarInPath',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p id="first">First</p><span>one</span><span>two</span><p id="second">Second</p><span>three</span>'
+      },
+      {
         message: 'should not render the loop (looping/commentedLoopInLoop.html)',
         template: 'looping/commentedLoopInLoop',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),

--- a/test/tests.js
+++ b/test/tests.js
@@ -365,6 +365,19 @@ export default [
         expected: '<p class="some-class">Some content</p>'
       },
       {
+        // a condition's value may name a {variable} anywhere in it rather than only at its head, and either way the value is not known until there is a model to read it from
+        message: 'should evaluate <if something=\'Some {contentWord}\'> as true, with the variable in the middle of the value (conditionals/conditionalValueVarInMiddle.html)',
+        template: 'conditionals/conditionalValueVarInMiddle',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p>true</p>'
+      },
+      {
+        message: 'should evaluate one line if "if-something" whose value names a {variable} in the middle (conditionals/oneLineValueVarInMiddle.html)',
+        template: 'conditionals/oneLineValueVarInMiddle',
+        run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),
+        expected: '<p class="matched">Some content</p>'
+      },
+      {
         message: 'should evaluate <if something> as true and the nested <if not:somethingElse> as false, triggering the nested <else> condition (conditionals/nestedConditional.html)',
         template: 'conditionals/nestedConditional',
         run: async (teddy, template, model, assert, expected) => assert(teddy.render(template, model), expected),


### PR DESCRIPTION
- Fixed a `<loop>` whose `through` names a `{variable}` in the middle of its path, rather than at its head, rendering nothing. Fixed the same in the value of a condition: An `<if>`, or a one line `if-`, whose value named a `{variable}` anywhere but at its head was compared against the text as written rather than against what the variable resolved to.
- Updated dependencies.