### PR TITLE
2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.2
+
+- Added `teddy.precompile` and `teddy.registerPrecompiled`, which let a browser render from the JavaScript Teddy would otherwise have built for a template at runtime. A `format` option writes it as an ES module, as CommonJS, or as a plain script.
+- Fixed `import teddy from 'teddy'` being unable to read a template from the filesystem in the ESM build.
+- Improved performance in various places.
+- Updated dependencies.
+
 ## 2.0.1
 
 - Fixed a `<loop>` whose `through` names a `{variable}` in the middle of its path, rather than at its head, rendering nothing. Fixed the same in the value of a condition: An `<if>`, or a one line `if-`, whose value named a `{variable}` anywhere but at its head was compared against the text as written rather than against what the variable resolved to.

--- a/cheerioPolyfill.js
+++ b/cheerioPolyfill.js
@@ -210,23 +210,27 @@ const doublyEncodedEntities = {
   '&amp;#39;': '&#39;',
   '&amp;#x2F;': '&#x2F;'
 }
-const entityEntries = Object.entries(doublyEncodedEntities)
+// built once rather than on every node of every serialization
+const entityFixes = Object.entries(doublyEncodedEntities).map(([doublyEncoded, singleEncoded]) => [new RegExp(doublyEncoded, 'g'), singleEncoded])
+
+// teddy renames src and href while the markup is a live dom, so that the browser does not try to fetch a url that is still a {variable}. a string is not a dom and cannot fetch anything, so the real attribute name goes back on as the markup leaves the dom. doing it here rather than at the end of a render is what saves every render a sweep of its whole output looking for these
+const deferredAttributes = /data-teddy-defer-attr-(src|href)/g
+
+// undoes what parsing the markup into a dom did to it: the double encoding a browser's serializer applies, and the attribute names teddy renamed on the way in
+function undoParserArtifacts (html) {
+  for (const [pattern, singleEncoded] of entityFixes) html = html.replace(pattern, singleEncoded)
+  return html.replace(deferredAttributes, '$1')
+}
 function getTeddyDOMInnerHTML (node) {
   // build html string
   let html = ''
   for (const child of node.childNodes) {
     if (child.nodeType === window.Node.ELEMENT_NODE) {
-      let outerHTML = child.outerHTML
-      for (const [doublyEncoded, singleEncoded] of entityEntries) outerHTML = outerHTML.replace(new RegExp(doublyEncoded, 'g'), singleEncoded)
-      html += outerHTML
+      html += undoParserArtifacts(child.outerHTML)
     } else if (child.nodeType === window.Node.TEXT_NODE) {
-      let textContent = child.textContent
-      for (const [doublyEncoded, singleEncoded] of entityEntries) textContent = textContent.replace(new RegExp(doublyEncoded, 'g'), singleEncoded)
-      html += textContent
+      html += undoParserArtifacts(child.textContent)
     } else if (child.nodeType === window.Node.COMMENT_NODE) {
-      let commentContent = child.textContent
-      for (const [doublyEncoded, singleEncoded] of entityEntries) commentContent = commentContent.replace(new RegExp(doublyEncoded, 'g'), singleEncoded)
-      html += `<!--${commentContent}-->`
+      html += `<!--${undoParserArtifacts(child.textContent)}-->`
     }
   }
 
@@ -244,8 +248,5 @@ function getTeddyDOMOuterHTML (node) {
     outerHTML = `<!--${node.textContent}-->`
   }
 
-  // replace doubly encoded entities
-  for (const [doublyEncoded, singleEncoded] of entityEntries) outerHTML = outerHTML.replace(new RegExp(doublyEncoded, 'g'), singleEncoded)
-
-  return outerHTML
+  return undoParserArtifacts(outerHTML)
 }

--- a/codegen.js
+++ b/codegen.js
@@ -42,9 +42,12 @@ export function emit (nodes, helpers) {
   const body = mergeWrites(`let o = ''\n${walk(nodes, state, 'o')}return o`)
   // eslint-disable-next-line no-new-func
   const compiled = new Function('m', 'r', 's', body)
-  const runtime = { ...helpers, flags: state.flags, branches: state.branches, nodes: state.nodes }
+  const data = { flags: state.flags, branches: state.branches, nodes: state.nodes }
+  const runtime = { ...helpers, ...data }
   return {
     source: body,
+    // what a precompiled copy of this template has to carry beside the source: the helpers are teddy's own, but these were worked out while writing the code that indexes into them
+    data,
     render: (model, renderState) => compiled(model, runtime, renderState)
   }
 }

--- a/codegenStub.js
+++ b/codegenStub.js
@@ -1,6 +1,8 @@
 // stands in for codegen.js in browser builds
 //
-// emitting javascript means building a function from a string at runtime, which a page served under a strict content security policy is not allowed to do. rather than ask every browser app to loosen its policy, browser builds render by walking the node tree the compiler built, which needs no such permission. doing it this way does remove a performance benefit server-rendered templates enjoy, but that is less important in browser contexts; security is more important
+// emitting javascript means building a function from a string at runtime, which a page served under a strict content security policy is not allowed to do. rather than ask every browser app to loosen its policy, browser builds render by walking the node tree the compiler built, which needs no such permission
+//
+// a browser can still have the emitted code, and the speed of it, by being given it already written: teddy.precompile names a template and writes its emitted javascript out as source, which a page loads as a script like any other. nothing is built from a string at runtime, so a strict policy is satisfied
 //
 // webpack swaps this file in the same way it swaps cheerio for the dom polyfill, so the emitter is not merely unused in a browser bundle: it is not in it
 

--- a/compiler.js
+++ b/compiler.js
@@ -109,7 +109,7 @@ export function createCompiler (deps) {
       if (arm.body === null) arm.body = compileMarkup(arm.bodySource, slots, slot.stack)
       return
     }
-    if (slot.bodySource !== undefined && slot.body === null) slot.body = compileMarkup(slot.bodySource, slots, slot.stack)
+    if (slot.bodySource !== null && slot.body === null) slot.body = compileMarkup(slot.bodySource, slots, slot.stack)
     // an argument's body is a template in its own right, rendered against the model the include is reached with
     if (slot.bindings) {
       for (const binding of slot.bindings) {
@@ -117,6 +117,48 @@ export function createCompiler (deps) {
       }
     }
   }
+  // every node is made here, and every one of them carries the same fields in the same order whether it uses them or not
+  //
+  // v8 gives an object its shape from the fields it is written with, and reading one field across a dozen different shapes is a lookup it cannot cache. renderNodes reads node.type off every node in a template, so a dozen shapes made that read, and the reads after it, as slow as a lookup gets. one shape makes them all the fastest kind. the nodes are built once when a template is compiled rather than once per render, so the fields a node does not use cost nothing worth counting
+  function makeNode (type) {
+    return {
+      type,
+      value: null,
+      source: null,
+      stack: null,
+      body: null,
+      bodySource: null,
+      branch: null,
+      index: 0,
+      through: null,
+      keyName: null,
+      valName: null,
+      conditionals: null,
+      outcomesNeedModel: false,
+      variantNeedsModel: false,
+      openTag: null,
+      closeTag: null,
+      tagName: null,
+      variants: null,
+      src: null,
+      bindings: null,
+      compiled: null,
+      valueSource: null,
+      ownValue: null,
+      name: null,
+      key: null,
+      maxAge: 0,
+      maxCaches: 0,
+      css: null,
+      js: null,
+      flags: null,
+      raw: false,
+      dollar: false,
+      path: null,
+      nameNodes: null
+    }
+  }
+
   function compileMarkup (source, slots, stack) {
     reportStrayClosingTags(source)
     const dom = cheerioLoad(source || '', cheerioOptions)
@@ -215,22 +257,24 @@ export function createCompiler (deps) {
         bodySource: dom(arm).html(),
         body: null
       })
-      slots.push({ type: 'arm', branch, index: branch.arms.length - 1, stack })
+      const armNode = makeNode('arm')
+      armNode.branch = branch
+      armNode.index = branch.arms.length - 1
+      armNode.stack = stack
+      slots.push(armNode)
       dom(arm).replaceWith(tokenFor(slots.length - 1))
     }
   }
 
   function claimLoop (dom, el, slots, stack) {
     const attribs = readAttribs(el)
-    slots.push({
-      type: 'loop',
-      stack,
-      through: attribValue(attribs, 'through'),
-      keyName: attribValue(attribs, 'key'),
-      valName: attribValue(attribs, 'val'),
-      bodySource: dom(el).html(),
-      body: null
-    })
+    const node = makeNode('loop')
+    node.stack = stack
+    node.through = attribValue(attribs, 'through')
+    node.keyName = attribValue(attribs, 'key')
+    node.valName = attribValue(attribs, 'val')
+    node.bodySource = dom(el).html()
+    slots.push(node)
     dom(el).replaceWith(tokenFor(slots.length - 1))
   }
 
@@ -274,19 +318,17 @@ export function createCompiler (deps) {
     // whether either half of a one line if has anything to ask a model about, settled here so that emitted code inside a <loop> knows not to build one. working out which outcomes apply needs a model only for a condition this could not settle, and writing the opening tag needs one only if the tag or an outcome holds a {variable}
     const outcomesNeedModel = conditionals.some(conditional => !conditional.checks)
     const variantNeedsModel = openTag.includes('{') || conditionals.some(conditional => (conditional.ifTrue || '').includes('{') || (conditional.ifFalse || '').includes('{'))
-    slots.push({
-      type: 'attrs',
-      conditionals,
-      outcomesNeedModel,
-      variantNeedsModel,
-      openTag,
-      closeTag,
-      tagName: tagNameOf(el),
-      variants: [],
-      bodySource: dom(el).html(),
-      body: null,
-      stack
-    })
+    const node = makeNode('attrs')
+    node.conditionals = conditionals
+    node.outcomesNeedModel = outcomesNeedModel
+    node.variantNeedsModel = variantNeedsModel
+    node.openTag = openTag
+    node.closeTag = closeTag
+    node.tagName = tagNameOf(el)
+    node.variants = []
+    node.bodySource = dom(el).html()
+    node.stack = stack
+    slots.push(node)
     dom(el).replaceWith(tokenFor(slots.length - 1))
   }
 
@@ -305,13 +347,12 @@ export function createCompiler (deps) {
 
     // a src that names a variable is not known until there is a model to read it from, so the partial behind it is loaded and compiled on the first render that asks for it and kept against that name
     if (src.includes('{')) {
-      slots.push({
-        type: 'dynamicInclude',
-        src,
-        bindings: readArgs(dom, el),
-        compiled: new Map(),
-        stack
-      })
+      const node = makeNode('dynamicInclude')
+      node.src = src
+      node.bindings = readArgs(dom, el)
+      node.compiled = new Map()
+      node.stack = stack
+      slots.push(node)
       dom(el).replaceWith(tokenFor(slots.length - 1))
       return
     }
@@ -328,13 +369,11 @@ export function createCompiler (deps) {
       markup = params.includeNotFoundBehavior === 'display' ? `Template "${src}" not found!` : ''
     }
 
-    slots.push({
-      type: 'scope',
-      bindings: readArgs(dom, el),
-      bodySource: markup,
-      body: null,
-      stack: stack.concat(src)
-    })
+    const node = makeNode('scope')
+    node.bindings = readArgs(dom, el)
+    node.bodySource = markup
+    node.stack = stack.concat(src)
+    slots.push(node)
     dom(el).replaceWith(tokenFor(slots.length - 1))
   }
 
@@ -413,22 +452,22 @@ export function createCompiler (deps) {
     const marked = []
     pushText(marked, closeTag && rebuilt.endsWith(closeTag) ? rebuilt.slice(0, rebuilt.length - closeTag.length) : rebuilt)
 
-    slots.push({
-      type: 'selection',
-      valueSource,
-      ownValue,
-      variants: [plain, marked],
-      closeTag,
-      bodySource: dom(el).html(),
-      body: null,
-      stack: []
-    })
+    const node = makeNode('selection')
+    node.valueSource = valueSource
+    node.ownValue = ownValue
+    node.variants = [plain, marked]
+    node.closeTag = closeTag
+    node.bodySource = dom(el).html()
+    node.stack = []
+    slots.push(node)
     dom(el).replaceWith(tokenFor(slots.length - 1))
   }
 
   // <noteddy> and <noparse> keep their contents out of teddy's hands. the interpreter lifts them out of the markup, renders everything else, and puts them back at the very end; here they simply become a piece of text nothing further is done to, which is the same thing said more directly
   function claimNoParse (dom, el, slots, keepTags) {
-    slots.push({ type: 'raw', value: keepTags ? dom(el).toString() : dom(el).html() })
+    const node = makeNode('raw')
+    node.value = keepTags ? dom(el).toString() : dom(el).html()
+    slots.push(node)
     dom(el).replaceWith(tokenFor(slots.length - 1))
   }
 
@@ -449,23 +488,24 @@ export function createCompiler (deps) {
   // a <cache> keeps the markup its body rendered to and writes that instead of rendering again. the interpreter does this in two halves, marking the element on the way in and storing what it produced once the output has gone stable; a compiled render knows when the body is finished, so it is one step here
   function claimCache (dom, el, slots, stack) {
     const attribs = readAttribs(el)
-    slots.push({
-      type: 'cache',
-      name: attribValue(attribs, 'name'),
-      // an absent key means the whole body is cached under one entry, which teddy calls 'none'
-      key: attribValue(attribs, 'key'),
-      maxAge: parseInt(attribValue(attribs, 'maxAge') || attribValue(attribs, 'maxage')) || 0,
-      maxCaches: parseInt(attribValue(attribs, 'maxCaches') || attribValue(attribs, 'maxcaches')) || 1000,
-      bodySource: dom(el).html(),
-      body: null,
-      stack
-    })
+    const node = makeNode('cache')
+    node.name = attribValue(attribs, 'name')
+    // an absent key means the whole body is cached under one entry, which teddy calls 'none'
+    node.key = attribValue(attribs, 'key')
+    node.maxAge = parseInt(attribValue(attribs, 'maxAge') || attribValue(attribs, 'maxage')) || 0
+    node.maxCaches = parseInt(attribValue(attribs, 'maxCaches') || attribValue(attribs, 'maxcaches')) || 1000
+    node.bodySource = dom(el).html()
+    node.stack = stack
+    slots.push(node)
     dom(el).replaceWith(tokenFor(slots.length - 1))
   }
 
   function claimInline (dom, el, slots) {
     const attribs = readAttribs(el)
-    slots.push({ type: 'inline', css: attribValue(attribs, 'css'), js: attribValue(attribs, 'js') })
+    const node = makeNode('inline')
+    node.css = attribValue(attribs, 'css')
+    node.js = attribValue(attribs, 'js')
+    slots.push(node)
     dom(el).replaceWith(tokenFor(slots.length - 1))
   }
 
@@ -631,6 +671,18 @@ export function createCompiler (deps) {
     return nodes
   }
 
+  function pushTextNode (nodes, value) {
+    const node = makeNode('text')
+    node.value = value
+    nodes.push(node)
+  }
+
+  function notFoundBody (src) {
+    const nodes = []
+    pushTextNode(nodes, params.includeNotFoundBehavior === 'display' ? `Template "${src}" not found!` : '')
+    return nodes
+  }
+
   function pushText (nodes, text) {
     if (!text) return
     let cursor = 0
@@ -664,29 +716,31 @@ export function createCompiler (deps) {
 
       // teddy substitutes a variable in both its {name} and its template literal ${name} form, so a dollar immediately before the brace is part of this variable's span and is consumed with it
       const spanStart = open > literalFrom && text[open - 1] === '$' ? open - 1 : open
-      if (spanStart > literalFrom) nodes.push({ type: 'text', value: text.slice(literalFrom, spanStart) })
+      if (spanStart > literalFrom) pushTextNode(nodes, text.slice(literalFrom, spanStart))
       if (computed) {
         const nameNodes = []
         pushText(nameNodes, inner)
-        nodes.push({ type: 'computedVar', nameNodes, source: text.slice(spanStart, close + 1) })
+        const node = makeNode('computedVar')
+        node.nameNodes = nameNodes
+        node.source = text.slice(spanStart, close + 1)
+        nodes.push(node)
       } else {
         // a variable's flags are the same for every render, so they are settled here rather than read off the end of its name every time
         const flags = variableFlags(inner)
-        nodes.push({
-          type: 'var',
-          name: inner,
-          flags,
-          source: text.slice(spanStart, close + 1),
-          dollar: spanStart !== open,
-          // only a raw variable can put markup into the page that a further look would parse: an escaped one cannot, and a no parse one is never looked at again
-          raw: flags.raw
-        })
+        const node = makeNode('var')
+        node.name = inner
+        node.flags = flags
+        node.source = text.slice(spanStart, close + 1)
+        node.dollar = spanStart !== open
+        // only a raw variable can put markup into the page that a further look would parse: an escaped one cannot, and a no parse one is never looked at again
+        node.raw = flags.raw
+        nodes.push(node)
       }
       cursor = close + 1
       literalFrom = cursor
     }
 
-    if (literalFrom < text.length) nodes.push({ type: 'text', value: text.slice(literalFrom) })
+    if (literalFrom < text.length) pushTextNode(nodes, text.slice(literalFrom))
   }
 
   // #endregion
@@ -762,7 +816,9 @@ export function createCompiler (deps) {
           break
 
         case 'var': {
-          const resolved = formatVariable(node.flags, getOrSetObjectByDotNotation(model, node.flags.name), model)
+          // the name is split once for the life of the template rather than on every render
+          if (node.path === null) node.path = node.flags.name.split('.')
+          const resolved = formatVariable(node.flags, getOrSetObjectByDotNotation(model, node.path), model)
           // nothing to write, so the variable stays in the markup verbatim
           if (!resolved) {
             out += node.source
@@ -935,7 +991,7 @@ export function createCompiler (deps) {
 
   // the model an included template sees: the one the include was reached with, plus its arguments
   function bindArgs (model, bindings, values) {
-    const localModel = Object.assign({}, model)
+    const localModel = Object.create(model || null)
     for (let i = 0; i < bindings.length; i++) getOrSetObjectByDotNotation(localModel, bindings[i].name, values[i])
     return localModel
   }
@@ -1062,10 +1118,12 @@ export function createCompiler (deps) {
   }
 
   // the model as a loop's body sees it: the model it was reached with, plus this iteration's key and val. emitted code needs this for the helpers it calls, which take a model rather than the javascript variables the emitted code keeps its locals in
+  //
+  // the enclosing model is reached through the prototype chain rather than copied. a loop of a thousand rows copied the whole model a thousand times, and because every copy started out owning nothing, writing this iteration's names into it also searched it for keys differing only in case each time round. an object made this way owns nothing but those two names, so neither cost is paid; a name holding a dot is left alone because setting one never did anything, and a value of undefined is left unset so that the enclosing model still answers for that name
   function loopScope (model, keyName, key, valName, value) {
-    const localModel = Object.assign({}, model)
-    getOrSetObjectByDotNotation(localModel, keyName, key)
-    getOrSetObjectByDotNotation(localModel, valName, value)
+    const localModel = Object.create(model || null)
+    if (keyName && key !== undefined && !keyName.includes('.')) localModel[keyName] = key
+    if (valName && value !== undefined && !valName.includes('.')) localModel[valName] = value
     return localModel
   }
 
@@ -1109,7 +1167,7 @@ export function createCompiler (deps) {
     }
     const markup = loadTemplate(src)
     body = markup === null
-      ? [{ type: 'text', value: params.includeNotFoundBehavior === 'display' ? `Template "${src}" not found!` : '' }]
+      ? notFoundBody(src)
       : compileTemplate(markup, node.stack.concat(src))
     node.compiled.set(src, body)
     return body
@@ -1121,10 +1179,10 @@ export function createCompiler (deps) {
 
     let out = ''
     const needsKey = !!node.keyName
-    const walk = loopWalk(collection, needsKey)
-    for (let i = 0; i < walk.length; i++) {
-      const key = needsKey ? walk[i] : null
-      out += renderNodes(node.body, loopScope(model, node.keyName, key, node.valName, needsKey ? collection[key] : walk[i]), state)
+    const items = loopWalk(collection, needsKey)
+    for (let i = 0; i < items.length; i++) {
+      const key = needsKey ? items[i] : null
+      out += renderNodes(node.body, loopScope(model, node.keyName, key, node.valName, needsKey ? collection[key] : items[i]), state)
     }
     return out
   }
@@ -1139,6 +1197,7 @@ export function createCompiler (deps) {
     renderNodes,
     isSelfContained,
     helpers: {
+      node: makeNode,
       get: getOrSetObjectByDotNotation,
       format: formatVariable,
       write: writeValue,

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
         "express": "5.2.1",
         "highlight.js": "11.12.0",
         "roosevelt": "0.33.2",
-        "sass": "1.103.1",
+        "sass": "1.104.0",
         "teddy": "../",
         "webpack": "5.110.3"
       },
@@ -18,7 +18,7 @@
         "http-server": "14.1.1",
         "nodemon": "3.1.14",
         "standard": "17.1.2",
-        "stylelint": "17.14.1",
+        "stylelint": "17.15.0",
         "stylelint-config-standard-scss": "17.0.0"
       },
       "engines": {
@@ -26,14 +26,14 @@
       }
     },
     "..": {
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cheerio": "1.2.0"
       },
       "devDependencies": {
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@playwright/test": "1.62.1",
+        "@playwright/test": "1.63.0",
         "c8": "12.0.0",
         "cross-env": "10.1.0",
         "eslint-plugin-html": "8.2.0",
@@ -340,9 +340,9 @@
       }
     },
     "node_modules/@dabh/diagnostics": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
-      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.9.tgz",
+      "integrity": "sha512-R6siwR65Hm+3yfgP7o8DKhNvputQAwfoz9zTc3kyDudnomj2/BcLmD+uGQQPICjuFUp8ounPBU+jmKsocwVVAg==",
       "license": "MIT",
       "dependencies": {
         "@so-ric/colorspace": "^1.1.6",
@@ -1852,9 +1852,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
-      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -1970,9 +1970,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1989,11 +1989,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3003,9 +3003,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.420",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
-      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6646,9 +6646,9 @@
       }
     },
     "node_modules/minimizer-webpack-plugin": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.8.0.tgz",
-      "integrity": "sha512-2cT9+goJfBhtMz+gJqejSf09ClgmYhPhccRb/fb0ztVbixt0BkO8mRuI26FoPPuUNkRk6iEDryWAIouc5W8eJA==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.10.0.tgz",
+      "integrity": "sha512-2//60T4S0X1Ug/dqLDOgDaGlZsN1Lv8hf8oB0NOV/KIHSaXlPwXBBIbim79dE2Z7NEs52ES8YHoSv6Lmsk+XNg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
@@ -6668,6 +6668,9 @@
       },
       "peerDependenciesMeta": {
         "@minify-html/node": {
+          "optional": true
+        },
+        "@napi-rs/image": {
           "optional": true
         },
         "@swc/core": {
@@ -6694,10 +6697,19 @@
         "html-minifier-terser": {
           "optional": true
         },
+        "imagemin": {
+          "optional": true
+        },
         "lightningcss": {
           "optional": true
         },
         "postcss": {
+          "optional": true
+        },
+        "sharp": {
+          "optional": true
+        },
+        "svgo": {
           "optional": true
         },
         "uglify-js": {
@@ -7610,9 +7622,9 @@
       "license": "MIT"
     },
     "node_modules/postcss-safe-parser": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
-      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.1.0.tgz",
+      "integrity": "sha512-1WzZxRLaAFwEh6Do+zyGpjWV3nGJNxxhuh7Ubu/q1ICImMgZJnLwhoaEpRbG4pJppp2Y1ncL9ffA2f+LhrefQg==",
       "dev": true,
       "funding": [
         {
@@ -7664,9 +7676,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
-      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8320,9 +8332,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.103.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.103.1.tgz",
-      "integrity": "sha512-9icZURbP51S6S0QGoyaeqk9uB06GNWxsFYWfH5RgpFgqK5FA8tJcM3AdVxrZEVJ7dz+L87nG95gBKf4VuaMHGw==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.104.0.tgz",
+      "integrity": "sha512-btHMApW2bgolvClhRW8AlQJzgI9lUB3pPSofBQQT+E46GWvf9o0TVQ13SYv5riWZVFyPN+JNz3TKW9XhBlc10w==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -9135,9 +9147,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "17.14.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.1.tgz",
-      "integrity": "sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==",
+      "version": "17.15.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.15.0.tgz",
+      "integrity": "sha512-mWIkesYQvQjf4Kvdeu9ns0IL8/K/wtjaGxPqsPd6DlLZvaQxGysJsocxUDrBcyHQ5VleAk4uSMat4yMrVED7PA==",
       "dev": true,
       "funding": [
         {
@@ -9151,14 +9163,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-calc": "^3.3.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.9",
         "@csstools/css-tokenizer": "^4.0.0",
         "@csstools/media-query-list-parser": "^5.0.0",
-        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.1",
         "@csstools/selector-specificity": "^6.0.0",
-        "colord": "^2.9.3",
+        "colord": "^2.10.0",
         "cosmiconfig": "^9.0.2",
         "css-functions-list": "^3.3.3",
         "css-tree": "^3.2.1",
@@ -9167,21 +9179,21 @@
         "fastest-levenshtein": "^1.0.16",
         "file-entry-cache": "^11.1.5",
         "global-modules": "^2.0.0",
-        "globby": "^16.2.1",
+        "globby": "^16.2.4",
         "globjoin": "^0.1.4",
         "html-tags": "^5.1.0",
-        "ignore": "^7.0.5",
+        "ignore": "^7.0.6",
         "import-meta-resolve": "^4.2.0",
         "mathml-tag-names": "^4.0.0",
         "meow": "^14.1.0",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.5.16",
+        "postcss": "^8.5.26",
         "postcss-safe-parser": "^7.0.1",
-        "postcss-selector-parser": "^7.1.4",
+        "postcss-selector-parser": "^7.1.5",
         "postcss-value-parser": "^4.2.0",
-        "string-width": "^8.2.1",
+        "string-width": "^8.2.2",
         "supports-hyperlinks": "^4.5.0",
         "svg-tags": "^1.0.0",
         "table": "^6.9.0",
@@ -9507,9 +9519,9 @@
       }
     },
     "node_modules/stylelint/node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -9527,7 +9539,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.17",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10060,9 +10072,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,14 +10,14 @@
     "highlight.js": "11.12.0",
     "roosevelt": "0.33.2",
     "teddy": "../",
-    "sass": "1.103.1",
+    "sass": "1.104.0",
     "webpack": "5.110.3"
   },
   "devDependencies": {
     "http-server": "14.1.1",
     "nodemon": "3.1.14",
     "standard": "17.1.2",
-    "stylelint": "17.14.1",
+    "stylelint": "17.15.0",
     "stylelint-config-standard-scss": "17.0.0"
   },
   "nodemonConfig": {

--- a/docs/statics/pages/usage.html
+++ b/docs/statics/pages/usage.html
@@ -37,8 +37,6 @@
         <li>In your Express config, make sure to include this line: <code>app.engine('html', teddy.__express)</code>.</li>
       </ul>
 
-      <p>If you're interested in using Teddy with the <a href='http://gulpjs.com'>gulp.js</a> build system for Node apps, check out the <a href='https://github.com/Csombek/gulp-teddy'>gulp-teddy</a> project.</p>
-
       <h2 id="variables">Variables</h2>
 
       <p>Display a variable by simply writing <code>{varName}</code> anywhere in the template. You can also use template literal <code>${templateLiteral}</code> variables as well.</p>
@@ -580,6 +578,49 @@
           <p><code>maxCaches</code>: The maximum number of caches that Teddy will be allowed to create for a given <code><!--#<cache>--></code> element. If the maximum is reached, Teddy will remove the oldest cache in the stack, where oldest is defined as the least recently created <em>or</em> accessed. Default: <code>1000</code>.</p>
         </li>
       </ul>
+
+      <h2 id="precompiling">Precompiling templates for the browser</h2>
+
+      <p>In Node.js, Teddy renders templates by converting the template code to JavaScript and running that. In a browser it cannot do that, because it would violate a strict <a href='https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP'>content security policy</a>. Browser builds thus render templates on-demand using a slower parser and compiler instead. You can safely use the faster JS converter method on the client too though if you precompile your templates in Node.js first and serve the precompiled JS to the browser instead of serving template code to the browser.</p>
+
+      <p>To do so, add a build step to your Node.js code:</p>
+
+      <pre><code class='language-javascript'>const teddy = require('teddy')
+const fs = require('fs')
+
+teddy.setTemplateRoot('views')
+fs.writeFileSync('public/page.js', teddy.precompile('page', { format: 'cjs' }))
+      </code></pre>
+
+      <p>What you get back is JavaScript source. Write it to a file, serve it, and let the page load it however that page loads anything else. Pass a <code>format</code> to say which way you want it written:</p>
+
+      <ul>
+        <li><code>'esm'</code> (the default): <code>export default</code>. For a bundler, for Node's <code>import</code>, and for <code>&lt;script type="module"&gt;</code>.</li>
+        <li><code>'cjs'</code>: <code>module.exports</code>. For <code>require</code>, and for a bundler that would rather have CommonJS.</li>
+        <li><code>'global'</code>: for a plain <code>&lt;script src&gt;</code> with no module loader anywhere. The templates collect on one <code>teddyPrecompiled</code> global, keyed by name, so a page can load as many of them as it likes.</li>
+      </ul>
+
+      <p>With <code>require</code>:</p>
+
+      <pre><code class='language-javascript'>const teddy = require('teddy/client')
+const page = require('./page.js')
+
+teddy.registerPrecompiled(page)
+document.body.innerHTML = teddy.render('page', model)
+      </code></pre>
+
+      <p>Or with no build tooling on the page at all, from <code>teddy.precompile('page', { format: 'global' })</code>:</p>
+
+      <pre><code class='language-html'><escape>
+<script src="/teddy.min.js"></script>
+<script src="/page.js"></script>
+<script>
+  teddy.registerPrecompiled(teddyPrecompiled['page'])
+  document.body.innerHTML = teddy.render('page', model)
+</script>
+      </escape></code></pre>
+
+      <p>From then on that template renders from the precompiled JavaScript rather than being compiled in the browser, which will result in much faster rendering.</p>
     </article>
   </arg>
 </include>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "teddy",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teddy",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cheerio": "1.2.0"
       },
       "devDependencies": {
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@playwright/test": "1.62.1",
+        "@playwright/test": "1.63.0",
         "c8": "12.0.0",
         "cross-env": "10.1.0",
         "eslint-plugin-html": "8.2.0",
@@ -688,13 +688,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
-      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.1"
+        "playwright": "1.63.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3306,21 +3306,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4847,9 +4832,9 @@
       }
     },
     "node_modules/minimizer-webpack-plugin": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.9.0.tgz",
-      "integrity": "sha512-OASqv+dewv8vjkOBjqMOHvxUaXhtGBLZAXq7JbmYE8TSzBvOswiGq5JcBdc8ypuLL/8YUT1OEyupga6/iqdyTA==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.10.0.tgz",
+      "integrity": "sha512-2//60T4S0X1Ug/dqLDOgDaGlZsN1Lv8hf8oB0NOV/KIHSaXlPwXBBIbim79dE2Z7NEs52ES8YHoSv6Lmsk+XNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5860,28 +5845,25 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
-      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.1"
+        "playwright-core": "1.63.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=20"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
-      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/teddy/graphs/contributors"
     }
   ],
-  "version": "2.0.1",
+  "version": "2.0.2",
   "files": [
     "dist",
     "docs/statics/pages",
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-    "@playwright/test": "1.62.1",
+    "@playwright/test": "1.63.0",
     "c8": "12.0.0",
     "cross-env": "10.1.0",
     "eslint-plugin-html": "8.2.0",
@@ -74,10 +74,11 @@
     "coverage-client": "npm run build -- --env coverage && nyc --silent playwright test && nyc report --reporter=json --report-dir=coverage/raw/client && npm run build",
     "lint": "standard && standard --plugin html",
     "lint-fix": "standard --fix && standard --plugin html --fix",
-    "test": "npm run test-server && npm run test-client",
-    "t": "npm run test-server && npm run test-client",
+    "test": "npm run test-server && npm run test-precompiled && npm run test-client",
+    "t": "npm run test-server && npm run test-precompiled && npm run test-client",
     "test-client": "npm run build && playwright test",
     "test-server": "npm run build && cross-env NODE_ENV=test node --test --test-timeout=60000 test/loaders/node.js",
+    "test-precompiled": "node test/comparePrecompiled.js",
     "prepack": "npm run build",
     "coverage-report": "node test/mergeCoverage.js"
   },

--- a/precompiled.js
+++ b/precompiled.js
@@ -1,0 +1,101 @@
+// the data a precompiled template carries beside its emitted javascript, written out and read back
+//
+// emitting javascript is what makes a render fast, and it needs to build a function from a string to do it, which a page under a strict content security policy may not do. a template compiled ahead of time does not have to: the function is written to a file as source, and the browser loads it as a script like any other. what has to travel with it is the data the emitted code indexes into, which is what this module writes and reads
+//
+// the shapes involved are not plain json. the same node list is reached from more than one place, an arm holds its branch and the branch holds the arm back, and a dynamic include keeps a map. so every object is written once into a table and referred to by its place in it, which handles sharing and circularity alike
+
+export const FORMAT = 1 // precompile version: a template compiled by one version of teddy and loaded by another whose format differs is refused rather than rendered into something wrong
+
+const REF = '$r'
+const MAP = '$m'
+const UNDEFINED = '$u'
+
+// the node types the compiler produces. a decoded object is rebuilt as a node when its type is one of these, so that it comes out with the same shape every other node has
+const NODE_TYPES = new Set(['text', 'var', 'arm', 'loop', 'attrs', 'scope', 'raw', 'inline', 'computedVar', 'selection', 'cache', 'dynamicInclude'])
+
+// true for an object that came out of the compiler's node factory. checking the type alone is not enough: a binding also has a name, and a conditional also has a type of sorts
+function isNode (value) {
+  return typeof value.type === 'string' && NODE_TYPES.has(value.type) && Object.prototype.hasOwnProperty.call(value, 'bodySource')
+}
+
+export function encode (value) {
+  const table = []
+  const places = new Map()
+
+  function write (value) {
+    if (value === undefined) return { [UNDEFINED]: 1 }
+    if (value === null || typeof value !== 'object') {
+      if (typeof value === 'function') throw new Error('teddy: a template holding a function in its compiled form cannot be precompiled')
+      return value
+    }
+
+    const seen = places.get(value)
+    if (seen !== undefined) return { [REF]: seen }
+    // the place is claimed before the contents are written, so that something reaching back to this object finds a reference rather than going round again
+    const place = table.length
+    places.set(value, place)
+    table.push(null)
+
+    if (value instanceof Map) {
+      table[place] = { [MAP]: [...value].map(([k, v]) => [write(k), write(v)]) }
+      return { [REF]: place }
+    }
+    if (Array.isArray(value)) {
+      table[place] = value.map(write)
+      return { [REF]: place }
+    }
+    const written = {}
+    for (const key of Object.keys(value)) written[key] = write(value[key])
+    if (isNode(value)) written.$n = value.type
+    table[place] = written
+    return { [REF]: place }
+  }
+
+  const root = write(value)
+  return { root, table }
+}
+
+// makeNode is the compiler's own node factory, passed in so that this module does not have to know what fields a node has
+export function decode (encoded, makeNode) {
+  const { root, table } = encoded
+  const built = new Array(table.length).fill(undefined)
+  const done = new Array(table.length).fill(false)
+
+  function read (value) {
+    if (value === null || typeof value !== 'object') return value
+    if (value[UNDEFINED] !== undefined) return undefined
+    // anything else write produced is a reference into the table
+    return at(value[REF])
+  }
+
+  function at (place) {
+    if (done[place]) return built[place]
+    const raw = table[place]
+
+    // the container is made and recorded before what is in it is read, so that something inside it referring back finds the same object rather than a second copy of it
+    if (Array.isArray(raw)) {
+      const out = []
+      built[place] = out
+      done[place] = true
+      for (const item of raw) out.push(read(item))
+      return out
+    }
+    if (raw[MAP] !== undefined) {
+      const out = new Map()
+      built[place] = out
+      done[place] = true
+      for (const [k, v] of raw[MAP]) out.set(read(k), read(v))
+      return out
+    }
+    const out = raw.$n === undefined ? {} : makeNode(raw.$n)
+    built[place] = out
+    done[place] = true
+    for (const key of Object.keys(raw)) {
+      if (key === '$n') continue
+      out[key] = read(raw[key])
+    }
+    return out
+  }
+
+  return read(root)
+}

--- a/teddy.js
+++ b/teddy.js
@@ -5,6 +5,7 @@ import path from 'path' // node path module
 import { load as cheerioLoad } from 'cheerio/slim' // dom parser
 import { createCompiler } from './compiler.js' // walks a template once so a render does not have to
 import { canEmit, emit } from './codegen.js' // turns what the compiler worked out into javascript; browser builds swap this for a stub
+import { encode, decode, FORMAT } from './precompiled.js' // reads and writes the data a template compiled ahead of time carries
 
 const cheerioOptions = { lowerCaseAttributeNames: false, decodeEntities: false }
 const browser = cheerioLoad.isCheerioPolyfill // true if we are executing in the browser context
@@ -433,30 +434,48 @@ function getOrSetObjectByDotNotation (obj, dotNotation, value) {
   if (typeof dotNotation === 'string') return getOrSetObjectByDotNotation(obj, dotNotation.split('.'), value)
   else if (dotNotation.length === 1 && value !== undefined) {
     // a lookup is case insensitive, so a key that differs from this one only in case has to go: leaving both in place means which one a later lookup finds depends on the order the keys happen to be in. this matters most for <include> <arg> names, because the browser lowercases attribute names and cheerio does not, so an <arg camelCase> would otherwise sit next to a model key of the same name in a different case
+    //
+    // only a key this object owns is ambiguous with the one about to be written, so only those are looked at. a key it merely inherits from the model an enclosing loop or include was reached with is shadowed by the write rather than left sitting behind it, and deleting one would reach back into a model that enclosing scope is still rendering from
     const key = dotNotation[0]
     if (!Object.prototype.hasOwnProperty.call(obj, key)) {
       const lowerCaseKey = key.toLowerCase()
-      for (const existing in obj) {
+      for (const existing of Object.keys(obj)) {
         if (existing !== key && existing.toLowerCase() === lowerCaseKey) delete obj[existing]
       }
     }
     obj[key] = value
     return obj[key]
-  } else if (dotNotation.length === 0) return obj
-  else if (dotNotation.length === 1) {
-    if (obj) return caseInsensitiveLookup(obj, dotNotation[0])
-    return false
-  } else return getOrSetObjectByDotNotation(caseInsensitiveLookup(obj, dotNotation[0]), dotNotation.slice(1), value)
+  } else {
+    // walked rather than recursed: the recursion handed each step a copy of the rest of the path, so a name of three segments allocated two arrays every time it was read
+    let current = obj
+    for (let i = 0; i < dotNotation.length; i++) {
+      if (!current) return false
+      current = caseInsensitiveLookup(current, dotNotation[i])
+    }
+    return current
+  }
   function caseInsensitiveLookup (obj, key) {
     if (key === 'length') return obj.length
     // a key that matches exactly is the overwhelming case, and answering it costs one lookup. the lowercased copy of the object below is only built when there is no exact match to be had, which is what stops a model lookup from costing as much as the object is wide on every single step of every single path
+    // asking what the object owns, rather than reading the key straight off it, is what makes an <arg> win against a model key that differs from it only in case. the browser lowercases attribute names, so an <arg escapeTest> arrives owned as escapetest while the model's own spelling is still reachable through the prototype chain: a plain read would find that one and stop, where the walk below prefers the key this object owns
     if (Object.prototype.hasOwnProperty.call(obj, key)) return obj[key]
+    // a loop body and an included template see the model they were reached with through the prototype chain rather than through a copy of it, so the keys worth looking at are the inherited ones too. a key the object owns answers ahead of one it inherits, which is what an exact match one line above would have done
     const lowerCaseKey = key.toLowerCase()
-    const normalizedObj = Object.keys(obj).reduce((acc, k) => {
-      acc[k.toLowerCase()] = obj[k]
-      return acc
-    }, {})
-    return normalizedObj[lowerCaseKey]
+    let own
+    let ownFound = false
+    let inherited
+    let inheritedFound = false
+    for (const k in obj) {
+      if (k.toLowerCase() !== lowerCaseKey) continue
+      if (Object.prototype.hasOwnProperty.call(obj, k)) {
+        own = obj[k]
+        ownFound = true
+      } else if (!inheritedFound) {
+        inherited = obj[k]
+        inheritedFound = true
+      }
+    }
+    return ownFound ? own : inherited
   }
 }
 
@@ -565,7 +584,7 @@ const compiler = createCompiler({
 // nodes is null for a template the compiler does not handle, and that answer is kept too, so a template it has already turned down is not walked again on every render only to be turned down again
 //
 // keyIsMarkup says the key is the template's own markup rather than a name it was looked up by. such an entry can never go stale, because the key is the content, so it is always kept: that is what makes teddy.compile() compile once even in development. an entry keyed by a name can go stale, since the file behind the name may change, so it is kept only on the same terms as the template source itself
-function prepareTemplate (cacheKey, markup, keyIsMarkup) {
+function prepareTemplate (cacheKey, markup, keyIsMarkup, emittedOut) {
   const keep = keyIsMarkup || params.cacheTemplates
   // give every repeated attribute name a unique one before the markup is parsed since html parsers strip duplicate attributes
   const prepared = markup.replace(/<([a-zA-Z][a-zA-Z0-9-]*)([^>]*)>/g, (match, tagName, attributes) => {
@@ -588,7 +607,10 @@ function prepareTemplate (cacheKey, markup, keyIsMarkup) {
   let render = null
   if (canEmit(nodes)) {
     try {
-      render = emit(nodes, compiler.helpers).render
+      const emitted = emit(nodes, compiler.helpers)
+      // only precompiling asks for this, and it is not kept on the entry: the source and the data behind it are wanted once, to be written out
+      if (emittedOut) emittedOut.emitted = emitted
+      render = emitted.render
     } catch (err) {
       if (params.verbosity > 1) console.warn(`teddy: could not emit javascript for this template, so it will be rendered by walking it instead: ${err.message}`)
       render = null
@@ -723,7 +745,7 @@ function render (template, model, callback) {
   // the entry is looked for before anything else happens, because reading the template and stripping its comments are template level work too
   let prepared = compiledCache.get(template)
   // a name may point at different markup than it did last time, so an entry keyed by one is only trusted on the same terms as the template source itself. an entry keyed by markup cannot go stale, because the key is the content
-  if (prepared && !prepared.keyIsMarkup && !params.cacheTemplates) prepared = undefined
+  if (prepared && !prepared.keyIsMarkup && !prepared.precompiled && !params.cacheTemplates) prepared = undefined
   if (!prepared) {
     let source = loadTemplate(template)
     // a name that resolves to nothing falls back to being rendered as though it were markup
@@ -743,11 +765,10 @@ function render (template, model, callback) {
   }
 
   if (browser) {
-    // fix double-encoding html entity bug in client-side mode
-    renderedTemplate = reverseDoubleEncodedEntities(renderedTemplate)
-
-    // now that we're done with the render, reset data-teddy-defer-attr-src and data-teddy-defer-attr-href to native attributes
-    renderedTemplate = renderedTemplate.replaceAll('data-teddy-defer-attr-src', 'src').replaceAll('data-teddy-defer-attr-href', 'href')
+    // the renamed src and href attributes are put back as the markup leaves the dom now, so a render no longer sweeps its whole output for them
+    //
+    // what is left is the double encoding, which can still arrive in a value the model supplied rather than through the parser. asking whether there is any is far cheaper than rewriting a page that has none, and nearly every page has none
+    if (renderedTemplate.includes('&amp;')) renderedTemplate = reverseDoubleEncodedEntities(renderedTemplate)
   }
 
   // cache the template
@@ -771,6 +792,61 @@ function render (template, model, callback) {
 
 // #endregion
 
+// writes a template out as the javascript teddy would otherwise have built for it at runtime, so that a browser can be handed the fast render rather than the slow one
+//
+// this runs where the emitter is, which is node: the returned string is an es module, meant to be written to a file at build time and loaded by the page that needs it. registerPrecompiled below is what the page then calls. nothing is built from a string at runtime, so a strict content security policy is satisfied
+const PRECOMPILED_WRAPPERS = {
+  // for a bundler, for node's `import`, and for a browser's <script type="module">
+  esm: body => `export default ${body}\n`,
+
+  // for `require`, and for a bundler that would rather have commonjs
+  cjs: body => `module.exports = ${body}\n`,
+
+  // for a plain <script src> with no module loader anywhere: the templates collect on one global, keyed by name, so that a page can load as many of them as it likes without them colliding
+  global: (body, name) => `;(function (root) {\n  root.teddyPrecompiled = root.teddyPrecompiled || {}\n  root.teddyPrecompiled[${JSON.stringify(name)}] = ${body}\n})(typeof globalThis !== 'undefined' ? globalThis : this)\n`
+}
+
+function precompile (template, options = {}) {
+  // the emitter is not in a browser build, so there would be nothing here to write out. saying so plainly beats reporting it as a template the emitter does not cover
+  if (browser) throw new Error('teddy: precompiling needs the code emitter, which browser builds do not carry. run teddy.precompile in node, at build time, and load what it writes with teddy.registerPrecompiled')
+  const format = options.format ?? 'esm'
+  const wrap = PRECOMPILED_WRAPPERS[format]
+  if (!wrap) throw new Error(`teddy: "${format}" is not a way teddy can write a precompiled template. it writes ${Object.keys(PRECOMPILED_WRAPPERS).join(', ')}`)
+  let source = loadTemplate(template)
+  if (source === null) source = template.slice(-5) === '.html' ? template.substring(0, template.length - 5) : template
+  const out = {}
+  prepareTemplate(template, source, template.includes('<'), out)
+  if (!out.emitted) throw new Error(`teddy: "${template}" holds something the emitter does not write code for, so it cannot be precompiled. it still renders by walking its node tree`)
+  const body = `{
+  format: ${FORMAT},
+  name: ${JSON.stringify(template)},
+  data: ${JSON.stringify(encode(out.emitted.data))},
+  render: function (m, r, s) {
+${out.emitted.source}
+  }
+}`
+  return `// teddy precompiled template: ${template}
+// generated: do not edit. rebuild this by running teddy.precompile() against the template again
+${wrap(body, template)}`
+}
+
+// takes what precompile wrote and renders with it from here on, in place of compiling the template
+function registerPrecompiled (artifact) {
+  if (!artifact || typeof artifact.render !== 'function') throw new Error('teddy: registerPrecompiled needs what teddy.precompile wrote')
+  if (artifact.format !== FORMAT) throw new Error(`teddy: this template was precompiled for teddy's format ${artifact.format}, and this teddy reads format ${FORMAT}. precompile it again`)
+  const data = decode(artifact.data, compiler.helpers.node)
+  const runtime = { ...compiler.helpers, ...data }
+  compiledCache.set(artifact.name, {
+    markup: '',
+    // there is no node tree behind a precompiled template: the emitted render is the only way it renders, and it is never the one that falls back to walking
+    nodes: null,
+    render: (model, state) => artifact.render(model, runtime, state),
+    keyIsMarkup: false,
+    precompiled: true
+  })
+  return artifact.name
+}
+
 export default {
   params,
   caches,
@@ -790,5 +866,7 @@ export default {
   setCache,
   clearCache,
   render,
+  precompile,
+  registerPrecompiled,
   __express: render
 }

--- a/test/comparePrecompiled.js
+++ b/test/comparePrecompiled.js
@@ -1,0 +1,96 @@
+// renders every fixture in test/templates twice and compares the bytes: once the ordinary way, and
+// once from what teddy.precompile wrote for it
+//
+// this is the gate a change to the emitter or to the precompiled format has to pass. compareBuilds
+// asks whether two builds of teddy agree; this asks whether a template compiled ahead of time
+// renders what the same template compiled at runtime renders, which is the whole promise of it
+//
+//   node test/comparePrecompiled.js
+import fs from 'fs'
+import path from 'path'
+import { pathToFileURL } from 'url'
+import teddy from '../teddy.js'
+import makeModel from './model.js'
+
+const root = 'test/templates'
+const scratch = path.join('test', '.precompiled')
+
+function templates (dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) templates(full, found)
+    else if (entry.name.endsWith('.html')) found.push(path.relative(root, full).replace(/\.html$/, ''))
+  }
+  return found
+}
+
+// test/model.js generates random strings, so the model is built once and cloned per render
+const sharedModel = makeModel()
+const freshModel = () => structuredClone(sharedModel)
+
+const names = templates(root).sort()
+fs.rmSync(scratch, { recursive: true, force: true })
+fs.mkdirSync(scratch, { recursive: true })
+
+let same = 0
+const skipped = []
+const refused = []
+const differences = []
+const errors = []
+
+for (const name of names) {
+  teddy.setVerbosity(0)
+  teddy.setTemplateRoot(root)
+  teddy.clearTemplates()
+  teddy.setCacheTemplates(false)
+
+  // a fixture that does not render the ordinary way has nothing to be compared against: one of them
+  // asks teddy to refuse a template that includes itself, and refusing is the right answer
+  let expected
+  try {
+    expected = teddy.render(name, freshModel())
+  } catch (e) {
+    skipped.push(`${name}: does not render the ordinary way either (${e.message.replace('teddy: ', '').slice(0, 60)}...)`)
+    continue
+  }
+
+  let artifact
+  try {
+    artifact = teddy.precompile(name)
+  } catch (e) {
+    // a template the emitter does not cover is reported rather than counted against the format
+    refused.push(`${name}: ${e.message.replace('teddy: ', '')}`)
+    continue
+  }
+
+  const file = path.join(scratch, name.replace(/[/\\]/g, '__') + '.mjs')
+  fs.writeFileSync(file, artifact)
+
+  let actual
+  try {
+    teddy.clearTemplates()
+    const loaded = (await import(pathToFileURL(path.resolve(file)).href)).default
+    teddy.registerPrecompiled(loaded)
+    actual = teddy.render(name, freshModel())
+  } catch (e) {
+    errors.push(`${name}: rendering it from its precompiled form threw: ${e.message}`)
+    continue
+  }
+
+  if (actual === expected) same++
+  else differences.push({ name, expected, actual })
+}
+
+fs.rmSync(scratch, { recursive: true, force: true })
+
+for (const problem of skipped) console.log(`SKIPPED  ${problem}`)
+for (const problem of errors) console.log(`THREW  ${problem}`)
+for (const problem of refused) console.log(`REFUSED  ${problem}`)
+for (const difference of differences) {
+  console.log(`\nDIFFERENT  ${difference.name}`)
+  console.log(`  the ordinary render: ${JSON.stringify(difference.expected.slice(0, 200))}`)
+  console.log(`  from precompiled:    ${JSON.stringify(difference.actual.slice(0, 200))}`)
+}
+
+console.log(`\n${same}/${names.length - skipped.length} comparable fixtures byte identical, ${refused.length} refused, ${differences.length} different, ${errors.length} threw, ${skipped.length} skipped`)
+process.exit(differences.length || errors.length ? 1 : 0)

--- a/test/loaders/node.js
+++ b/test/loaders/node.js
@@ -42,7 +42,7 @@ for (const testGroup of testsToRun) {
 
     for (const test of testGroup.tests) {
       if (test.skip) continue
-      if (test.runMocha) test.run = test.runMocha
+      if (test.runNode) test.run = test.runNode
       if (!test.run) continue
       else it(test.message, async () => await test.run(teddy, test.template, model, teddyAssert, test.expected))
     }

--- a/test/mergeCoverage.js
+++ b/test/mergeCoverage.js
@@ -64,15 +64,24 @@ for (const [sourcePath, data] of Object.entries(files).sort()) {
     either: total - uncovered.length,
     percent: total ? ((total - uncovered.length) / total * 100) : 100
   })
-  // a line only one half considers executable at all is usually a function's declaration or closing brace, which the two instrumenters disagree about counting; saying which half claimed it stops that reading as a real gap
+  // consecutive lines are reported as one range rather than one by one: a gap is nearly always a
+  // whole function nothing calls, and naming every line of it buried that under a wall of numbers
+  //
+  // which halves consider a line executable is carried along, because a line only one of them counts
+  // is usually a function's declaration or its closing brace, which the two instrumenters disagree
+  // about. saying so stops that reading as a real gap
   if (uncovered.length) {
-    gaps.push({
-      name,
-      uncovered: uncovered.map(line => {
-        const claimedBy = halves.map(h => h.label).filter(label => data.executableByHalf[label]?.has(line))
-        return claimedBy.length === halves.length ? String(line) : `${line} (only ${claimedBy.join(' and ')} counts this line)`
-      })
-    })
+    const claimedBy = line => halves.map(h => h.label).filter(label => data.executableByHalf[label]?.has(line)).join('+')
+    const runs = []
+    for (const line of uncovered) {
+      const claim = claimedBy(line)
+      const last = runs[runs.length - 1]
+      if (last && line === last.to + 1) {
+        last.to = line
+        if (!last.claims.includes(claim)) last.claims.push(claim)
+      } else runs.push({ from: line, to: line, claims: [claim] })
+    }
+    gaps.push({ name, runs, count: uncovered.length })
   }
 }
 
@@ -88,8 +97,29 @@ const overallEither = rows.reduce((sum, r) => sum + r.either, 0)
 console.log(`\n  ${'all files'.padEnd(width)}  ${String(overallTotal).padStart(6)}  ${''.padStart(7)}  ${''.padStart(7)}  ${String(overallEither).padStart(7)}  ${(overallEither / overallTotal * 100).toFixed(2).padStart(7)}`)
 
 if (gaps.length) {
-  console.log('\nlines nothing executes:')
-  for (const gap of gaps) console.log(`  ${gap.name}: ${gap.uncovered.join(', ')}`)
+  const everyHalf = halves.map(h => h.label).join('+')
+  // one row per run of lines, so a gap reads as the thing it is rather than as a list of numbers
+  const gapRows = gaps.flatMap(gap => gap.runs.map(run => ({
+    name: gap.name,
+    lines: run.from === run.to ? String(run.from) : `${run.from}-${run.to}`,
+    count: run.to - run.from + 1,
+    countedBy: run.claims.length > 1 ? 'mixed' : run.claims[0] === everyHalf ? 'both' : run.claims[0] || 'neither'
+  })))
+
+  const nameWidth = Math.max(...gapRows.map(r => r.name.length), 4)
+  const lineWidth = Math.max(...gapRows.map(r => r.lines.length), 5)
+  console.log('\nlines nothing executes:\n')
+  console.log(`  ${'file'.padEnd(nameWidth)}  ${'lines'.padEnd(lineWidth)}  ${'count'.padStart(5)}  counted by`)
+  console.log(`  ${'-'.repeat(nameWidth)}  ${'-'.repeat(lineWidth)}  ${'-'.repeat(5)}  ${'-'.repeat(10)}`)
+  for (const r of gapRows) {
+    console.log(`  ${r.name.padEnd(nameWidth)}  ${r.lines.padEnd(lineWidth)}  ${String(r.count).padStart(5)}  ${r.countedBy}`)
+  }
+
+  const totals = gaps.map(gap => `${gap.name} ${gap.count}`).join(', ')
+  console.log(`\n  ${gaps.reduce((sum, gap) => sum + gap.count, 0)} lines in ${gapRows.length} runs: ${totals}`)
+  console.log('\n  counted by says which halves\' instrumenter treated the line as executable at all.')
+  console.log('  a run counted by one half, or mixed, is usually a declaration or a closing brace the')
+  console.log('  two disagree about rather than logic nothing reaches.')
 } else {
   console.log('\nevery executable line is executed by one half or the other')
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -11,10 +11,10 @@ function testTemplateNames (dir, base = dir, found = []) {
   return found
 }
 
-// these tests are shared by both mocha and playwright
+// these tests are shared by both runners: node's own test runner, and playwright
 // to skip test groups or individual tests, add `skip: true` to the group or test object
 // to test an individual group or test, add `only: true` to the group or test object
-// to run a test only in mocha or only in playwright, use `runMocha` or `runPlaywright` instead of `run`
+// to run a test only in node or only in a browser, use `runNode` or `runPlaywright` instead of `run`
 // if multiple results are acceptable, make `expected` an array of strings rather than a string
 // to see console output from the client-side tests, go to test/loaders/playwright.js and uncomment the debug code
 
@@ -1164,7 +1164,7 @@ export default [
       {
         // a whole template cache is keyed on a model value, and that value becomes the name of an entry. a name is always a string, so a key whose value is not one has to be read back as the string it was stored under or the entry is never found again
         message: 'should find a whole template cache entry again when the key it is stored under is not a string',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const markup = '<p>{n}</p>'
           const answers = []
           for (const keyVal of ['a1', 42, 0, '']) {
@@ -1181,7 +1181,7 @@ export default [
       },
       {
         message: 'should still re-render a whole template cache entry once it is older than its max age',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const markup = '<p>{n}</p>'
           teddy.clearTemplates()
           teddy.setCache({ template: markup, key: 'id', maxAge: 60000 })
@@ -1918,7 +1918,7 @@ export default [
     tests: [
       {
         message: 'should read a template again after it changes, rather than caching it, by default',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const file = 'test/templates/misc/cacheProbe.html'
           fs.writeFileSync(file, '<p>before</p>')
           teddy.clearTemplates()
@@ -1932,7 +1932,7 @@ export default [
       },
       {
         message: 'should keep a template it already read when the cache option is on',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const file = 'test/templates/misc/cacheProbeOn.html'
           fs.writeFileSync(file, '<p>before</p>')
           teddy.clearTemplates()
@@ -1947,7 +1947,7 @@ export default [
       },
       {
         message: "should take caching from express's view cache setting when no cache option is given",
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const file = 'test/templates/misc/cacheProbeExpress.html'
           fs.writeFileSync(file, '<p>before</p>')
           teddy.clearTemplates()
@@ -1968,7 +1968,7 @@ export default [
       },
       {
         message: 'should let an explicit cache option override the view cache setting',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const file = 'test/templates/misc/cacheProbeOverride.html'
           fs.writeFileSync(file, '<p>before</p>')
           teddy.clearTemplates()
@@ -1983,7 +1983,7 @@ export default [
       },
       {
         message: 'should read an included template again after it changes',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const partial = 'test/templates/misc/cachePartial.html'
           const page = 'test/templates/misc/cachePage.html'
           fs.writeFileSync(partial, '<span>before</span>')
@@ -2000,7 +2000,7 @@ export default [
       },
       {
         message: 'should prefer a template registered with setTemplate over a file of the same name',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const file = 'test/templates/misc/cacheRegistered.html'
           fs.writeFileSync(file, '<p>from the filesystem</p>')
           teddy.clearTemplates()
@@ -2052,7 +2052,7 @@ export default [
     tests: [
       {
         message: 'should be able require teddy.cjs',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           if (fs.existsSync('test/client.cjs')) fs.rmSync('test/client.cjs')
 
           fs.writeFileSync('test/client.cjs', 'const teddy = require("../dist/teddy.cjs")\nconsole.log(teddy)')
@@ -2066,7 +2066,7 @@ export default [
       },
       {
         message: 'should be able to import teddy.mjs',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           if (fs.existsSync('test/client.js')) fs.rmSync('test/client.js')
 
           fs.writeFileSync('test/client.js', 'import teddy from "../dist/teddy.mjs"\nconsole.log(teddy)')
@@ -2080,7 +2080,7 @@ export default [
       },
       {
         message: 'should be able require teddy.client.cjs',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           if (fs.existsSync('test/client.cjs')) fs.rmSync('test/client.cjs')
 
           fs.writeFileSync('test/client.cjs', 'const teddy = require("../dist/teddy.client.cjs")\nconsole.log(teddy)')
@@ -2094,7 +2094,7 @@ export default [
       },
       {
         message: 'should be able to import teddy.client.mjs',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           if (fs.existsSync('test/client.js')) fs.rmSync('test/client.js')
 
           fs.writeFileSync('test/client.js', 'import teddy from "../dist/teddy.client.mjs"\nconsole.log(teddy)')
@@ -2108,7 +2108,7 @@ export default [
       },
       {
         message: 'should be able to import teddy.min.mjs',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           if (fs.existsSync('test/client.js')) fs.rmSync('test/client.js')
 
           fs.writeFileSync('test/client.js', 'import teddy from "../dist/teddy.min.mjs"\nconsole.log(teddy)')
@@ -2190,7 +2190,7 @@ export default [
       },
       {
         message: 'should write out a value that refers back to itself rather than resolving forever, and say which values led round the loop',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const said = []
           const error = console.error
           console.error = message => said.push(message)
@@ -2208,7 +2208,7 @@ export default [
       },
       {
         message: 'should say so when a template closes a tag it never opened',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const said = []
           const warn = console.warn
           console.warn = message => said.push(message)
@@ -2226,7 +2226,7 @@ export default [
       },
       {
         message: 'should say so when a variable is given markup that does not open and close its own tags',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const said = []
           const warn = console.warn
           console.warn = message => said.push(message)
@@ -2243,7 +2243,7 @@ export default [
       },
       {
         message: 'should say so when an outcome attribute has no if- condition to go with it',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const said = []
           const warn = console.warn
           console.warn = message => said.push(message)
@@ -2262,7 +2262,7 @@ export default [
       },
       {
         message: 'should say so when an <arg> has no <include> around it',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const said = []
           const warn = console.warn
           console.warn = message => said.push(message)
@@ -2298,7 +2298,7 @@ export default [
       },
       {
         message: 'should say so when a selected-value cannot reach the elements it would mark',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const said = []
           const warn = console.warn
           console.warn = message => said.push(message)
@@ -2320,7 +2320,7 @@ export default [
         //
         // it has no runPlaywright counterpart on purpose: browser builds do not carry the emitter at all, so there is nothing there to fall back from
         message: 'should emit javascript for every template in the test suite rather than falling back to walking it',
-        runMocha: async (teddy, template, model, assert, expected) => {
+        runNode: async (teddy, template, model, assert, expected) => {
           const refused = []
           const warn = console.warn
           console.warn = message => {
@@ -2342,6 +2342,137 @@ export default [
           assert(refused.length ? refused.join(' | ') : 'none', 'none')
         },
         expected: 'none'
+      }
+    ]
+  },
+  {
+    // precompiling writes out the javascript teddy would otherwise have built at runtime, so that a
+    // browser can be handed the fast render rather than the slow one. it only runs in node, where the
+    // emitter is, so these are runNode rather than run
+    //
+    // test/comparePrecompiled.js does the same across every fixture; these cover the shapes that are
+    // easiest to get wrong and the ways precompiling is meant to refuse
+    describe: 'Precompiling',
+    tests: [
+      {
+        message: 'should render a precompiled template to the same bytes as compiling it at runtime',
+        runNode: async (teddy, template, model, assert, expected) => {
+          // one fixture for each shape the encoder has to survive: an arm that holds the branch that
+          // holds it back, a body reached from more than one place, the arguments an include binds,
+          // the variant lists a selection carries, and the map a dynamic include keeps
+          const names = ['conditionals/if', 'looping/nestedLoops', 'includes/includeWithArg', 'looping/selectOptions', 'includes/dynamicInclude', 'misc/variable']
+          const answers = []
+          for (const name of names) {
+            teddy.setTemplateRoot('test/templates')
+            teddy.clearTemplates()
+            const runtime = teddy.render(name, structuredClone(model))
+            const artifact = teddy.precompile(name)
+            teddy.clearTemplates()
+            teddy.registerPrecompiled((await import('data:text/javascript,' + encodeURIComponent(artifact))).default)
+            answers.push(teddy.render(name, structuredClone(model)) === runtime ? 'same' : 'DIFFERENT: ' + name)
+          }
+          teddy.clearTemplates()
+          assert(answers.join(', '), names.map(() => 'same').join(', '))
+        },
+        expected: 'same, same, same, same, same, same'
+      },
+      {
+        message: 'should write a precompiled template that loads as an es module, as commonjs, or as a plain script',
+        runNode: async (teddy, template, model, assert, expected) => {
+          const { mkdtempSync, writeFileSync, rmSync } = await import('fs')
+          const { tmpdir } = await import('os')
+          const { join } = await import('path')
+          const { createRequire } = await import('module')
+          const name = 'misc/variable'
+          teddy.setTemplateRoot('test/templates')
+          teddy.clearTemplates()
+          const runtime = teddy.render(name, structuredClone(model))
+          const scratch = mkdtempSync(join(tmpdir(), 'teddy-formats-'))
+          const answers = []
+          try {
+            // an es module and a plain script are both valid module bodies, so both can be reached
+            // by importing them: the module one exports what it wrote, the plain one puts it on a
+            // global. commonjs is the one that needs a require, since `module` is not a thing here
+            for (const format of ['esm', 'global']) {
+              const artifact = teddy.precompile(name, { format })
+              const loaded = await import('data:text/javascript,' + encodeURIComponent(artifact))
+              teddy.clearTemplates()
+              teddy.registerPrecompiled(format === 'esm' ? loaded.default : globalThis.teddyPrecompiled[name])
+              answers.push(`${format} ${teddy.render(name, structuredClone(model)) === runtime ? 'same' : 'DIFFERENT'}`)
+            }
+            const file = join(scratch, 'template.cjs')
+            writeFileSync(file, teddy.precompile(name, { format: 'cjs' }))
+            teddy.clearTemplates()
+            teddy.registerPrecompiled(createRequire(import.meta.url)(file))
+            answers.push(`cjs ${teddy.render(name, structuredClone(model)) === runtime ? 'same' : 'DIFFERENT'}`)
+          } finally {
+            rmSync(scratch, { recursive: true, force: true })
+            delete globalThis.teddyPrecompiled
+            teddy.clearTemplates()
+          }
+          assert(answers.join(', '), 'esm same, global same, cjs same')
+        },
+        expected: 'esm same, global same, cjs same'
+      },
+      {
+        message: 'should refuse to write a precompiled template in a way it does not know how to write',
+        runNode: async (teddy, template, model, assert, expected) => {
+          teddy.setTemplateRoot('test/templates')
+          let answer = 'wrote it anyway'
+          try {
+            teddy.precompile('misc/variable', { format: 'commonjs' })
+          } catch (err) {
+            answer = err.message.includes('is not a way teddy can write') ? 'refused' : err.message
+          }
+          assert(answer, 'refused')
+        },
+        expected: 'refused'
+      },
+      {
+        message: 'should keep rendering a precompiled template with template caching switched off, there being no source behind it to have gone stale',
+        runNode: async (teddy, template, model, assert, expected) => {
+          teddy.setTemplateRoot('test/templates')
+          teddy.clearTemplates()
+          const artifact = teddy.precompile('misc/variable')
+          teddy.clearTemplates()
+          teddy.setCacheTemplates(false)
+          teddy.registerPrecompiled((await import('data:text/javascript,' + encodeURIComponent(artifact))).default)
+          const first = teddy.render('misc/variable', structuredClone(model))
+          const second = teddy.render('misc/variable', structuredClone(model))
+          teddy.setCacheTemplates(true)
+          teddy.clearTemplates()
+          assert(first === second && first.length > 0 ? 'still precompiled' : 'lost it', 'still precompiled')
+        },
+        expected: 'still precompiled'
+      },
+      {
+        message: 'should refuse a precompiled template written for a different format',
+        runNode: async (teddy, template, model, assert, expected) => {
+          let answer = 'accepted it'
+          try {
+            teddy.registerPrecompiled({ format: 0, name: 'x', data: { root: null, table: [] }, render: () => '' })
+          } catch (err) {
+            answer = err.message.includes('precompile it again') ? 'refused' : err.message
+          }
+          assert(answer, 'refused')
+        },
+        expected: 'refused'
+      },
+      {
+        message: 'should refuse something that is not a precompiled template at all',
+        runNode: async (teddy, template, model, assert, expected) => {
+          const answers = []
+          for (const bad of [null, {}, { format: 1, name: 'x' }]) {
+            try {
+              teddy.registerPrecompiled(bad)
+              answers.push('accepted it')
+            } catch (err) {
+              answers.push(err.message.includes('needs what teddy.precompile wrote') ? 'refused' : err.message)
+            }
+          }
+          assert(answers.join(', '), 'refused, refused, refused')
+        },
+        expected: 'refused, refused, refused'
       }
     ]
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ export default [
     experiments: {
       outputModule: true
     },
+    target: 'node',
     mode: 'development',
     devtool: 'source-map',
     optimization: {


### PR DESCRIPTION
- Added `teddy.precompile` and `teddy.registerPrecompiled`, which let a browser render from the JavaScript Teddy would otherwise have built for a template at runtime. A `format` option writes it as an ES module, as CommonJS, or as a plain script.
- Fixed `import teddy from 'teddy'` being unable to read a template from the filesystem in the ESM build.
- Improved performance in various places.
- Updated dependencies.